### PR TITLE
Change all uses of logging mechanism to new style

### DIFF
--- a/kernel/async/monitor-common/async/DeletionMonitor.hh
+++ b/kernel/async/monitor-common/async/DeletionMonitor.hh
@@ -43,7 +43,7 @@ public:
   void releaseRef() {
     auto result = refcount.fetch_sub(1);
     if (result == 0 && deleteTask != nullptr) {
-      mlog::async.detail(this, "schedule delete task");
+      MLOG_DETAIL(mlog::async, this, "schedule delete task");
       getLocalPlace().pushShared(deleteTask);
     }
   }
@@ -53,7 +53,7 @@ public:
     refcount++;
     deleteTask = msg->set(fun);
     if (--refcount == 0) {
-      mlog::async.detail(this, "schedule delete task immediately");
+      MLOG_DETAIL(mlog::async, this, "schedule delete task immediately");
       getLocalPlace().pushShared(deleteTask);
     }
   }

--- a/kernel/async/monitor-common/async/Place.cc
+++ b/kernel/async/monitor-common/async/Place.cc
@@ -34,7 +34,7 @@ namespace async {
 
   void Place::init(size_t apicID)
   {
-    mlog::async.info("init Place", DVAR(this), DVAR(apicID));
+    MLOG_INFO(mlog::async, "init Place", DVAR(this), DVAR(apicID));
     this->apicID = apicID;
     this->nestingMonitor = true;
     this->_cr3 = PhysPtr<void>(cpu::getPageTable());
@@ -46,7 +46,7 @@ namespace async {
     Tasklet* msg = queue.pull();
     while (true) {
       if (msg != nullptr) {
-        mlog::async.detail(this, "run tasklet", msg);
+        MLOG_DETAIL(mlog::async, this, "run tasklet", msg);
         msg->run();
       } else {
         if (queue.tryRelease()) break;

--- a/kernel/async/monitor-common/async/Place.hh
+++ b/kernel/async/monitor-common/async/Place.hh
@@ -61,7 +61,7 @@ public:
     if (mode == ASYNC) {
       pushPrivate(msg);
     } else {
-      mlog::async.detail(this, "run tasklet", msg);
+      MLOG_DETAIL(mlog::async, this, "run tasklet", msg);
       msg->run();
     }
   }
@@ -72,7 +72,7 @@ public:
   }
 
   void pushShared(Tasklet* msg) {
-    mlog::async.detail(this, "push shared", msg);
+    MLOG_DETAIL(mlog::async, this, "push shared", msg);
     if (queue.push(msg)) wakeup();
   }
 
@@ -93,7 +93,7 @@ public:
 protected:
   void pushPrivate(Tasklet* msg) {
     ASSERT(isLocal());
-    mlog::async.detail(this, "push private", msg);
+    MLOG_DETAIL(mlog::async, this, "push private", msg);
     queue.pushPrivate(msg);
   }
 

--- a/kernel/async/monitor-common/async/Tasklet.hh
+++ b/kernel/async/monitor-common/async/Tasklet.hh
@@ -83,9 +83,9 @@ protected:
 public:
   void print()
   {
-    mlog::async.info("tasklet", this, "handler", handler, "hash", hash32(payload, 48));
+    MLOG_INFO(mlog::async, "tasklet", this, "handler", handler, "hash", hash32(payload, 48));
     for (auto row = 0; row < 6; ++row) {
-      mlog::async.detail(DMDUMP(&payload[row*8], 8));
+      MLOG_DETAIL(mlog::async, DMDUMP(&payload[row*8], 8));
     }
   }
 

--- a/kernel/async/monitor-delegating/async/DelegationQueue.hh
+++ b/kernel/async/monitor-delegating/async/DelegationQueue.hh
@@ -54,7 +54,7 @@ public:
   DelegationQueueLIFO() : head(nullptr), tail(FREE) {}
   
   bool push(Tasklet* msg) {
-    //mlog::async.detail("push", DVAR(this), DVAR(msg));
+    //MLOG_DETAIL(mlog::async, "push", DVAR(this), DVAR(msg));
     msg->nextTasklet = LOCKED; // mark as incomplete push (TODO: should that be a SC store?)
     TaskletBase* oldtail = tail.exchange(msg); // replace the tail
     // complete the push
@@ -70,7 +70,7 @@ public:
   /** try to release the lock */
   bool tryRelease()
   {
-    //mlog::async.detail("tryRelease", DVAR(this));
+    //MLOG_DETAIL(mlog::async, "tryRelease", DVAR(this));
     if (head) {
       // there are tasklets in the private queue
       return false;
@@ -84,11 +84,11 @@ public:
 
   Tasklet* pop()
   {
-    //mlog::async.detail("pop", DVAR(this));
+    //MLOG_DETAIL(mlog::async, "pop", DVAR(this));
     auto current = head;
     if (!current) {
       current = tail.exchange(LOCKED); // detach tail
-      //mlog::async.detail("detatch tail", DVAR(this), DVAR(current));
+      //MLOG_DETAIL(mlog::async, "detatch tail", DVAR(this), DVAR(current));
     }
     do { // wait until the push is no longer marked as incomplete
         // use exchange in order to avoid shared state of cacheline
@@ -97,7 +97,7 @@ public:
         // sleep for a short amount of cycles
         hwthread_pause();
     } while (true);
-    //mlog::async.detail("new head", DVAR(this), DVAR(head));
+    //MLOG_DETAIL(mlog::async, "new head", DVAR(this), DVAR(head));
     if (current == LOCKED) {
       return nullptr;
     } else {

--- a/kernel/async/monitor-delegating/async/MonitorDelegating.hh
+++ b/kernel/async/monitor-delegating/async/MonitorDelegating.hh
@@ -59,16 +59,16 @@ public:
   {
     if (!requestQueue.tryRelease()) {
       auto msg = requestQueue.pop();
-      mlog::async.info(this, "after pop");
+      MLOG_INFO(mlog::async, this, "after pop");
       enqueue(msg);
     }
     // if in response, the response is responsible
     // for releasing the monitor
     if (!inResponse) {
-      mlog::async.info(this, "release in request");
+      MLOG_INFO(mlog::async, this, "release in request");
       release();
     } else {
-      mlog::async.info(this, "release in response");
+      MLOG_INFO(mlog::async, this, "release in response");
     }
     releaseRef();
   }
@@ -95,21 +95,21 @@ protected:
   void enqueue(Tasklet* msg)
   {
     if (queue.push(msg)) { // first
-      mlog::async.info(this, "acquired monitor");
+      MLOG_INFO(mlog::async, this, "acquired monitor");
       msg = queue.pop();
       getLocalPlace().runLocal(msg);
     } else {
-        mlog::async.info(this, "delegated monitor");
+        MLOG_INFO(mlog::async, this, "delegated monitor");
     }
   }
 
   void release() {
     if (!queue.tryRelease()) {
-      mlog::async.info(this, "reschedule monitor");
+      MLOG_INFO(mlog::async, this, "reschedule monitor");
       auto msg = queue.pop();
       getLocalPlace().runLocal(msg);
     } else {
-      mlog::async.info(this, "released monitor");
+      MLOG_INFO(mlog::async, this, "released monitor");
     }
   }
 

--- a/kernel/async/nested-monitor-delegating/async/NestedMonitorDelegating.cc
+++ b/kernel/async/nested-monitor-delegating/async/NestedMonitorDelegating.cc
@@ -34,7 +34,7 @@ namespace async {
     if (waitq.push(msg)) { // first push, acquired exclusive access
       this->acquireRef(); // mark object as used
       Place* myPlace = &getLocalPlace();
-      mlog::async.detail("NMD",this, "req acquired waitq", DVAR(msg), DVAR(myPlace));
+      MLOG_DETAIL(mlog::async, "NMD",this, "req acquired waitq", DVAR(msg), DVAR(myPlace));
       home.store(myPlace, std::memory_order_relaxed);
       auto tsk = waitq.pull(); // has to be successfull because of our enqueue
       ASSERT(tsk != nullptr);
@@ -46,7 +46,7 @@ namespace async {
     Place* myPlace = home.load(std::memory_order_relaxed);
     ASSERT(myPlace == &getLocalPlace());
     auto tsk = waitq.pull(); // try to run the next waiting request
-    mlog::async.detail("NMD",this, "requestDone", DVAR(myPlace), DVAR(tsk));
+    MLOG_DETAIL(mlog::async, "NMD",this, "requestDone", DVAR(myPlace), DVAR(tsk));
     if (tsk != nullptr) {
       myPlace->runLocal(tsk, Place::MAYINLINE); // exploit tail recursion
     } else { // try to release

--- a/kernel/boot/apboot-acpi/boot/ACPIApicTopology.cc
+++ b/kernel/boot/apboot-acpi/boot/ACPIApicTopology.cc
@@ -32,16 +32,16 @@ namespace mythos {
   ACPIApicTopology::ACPIApicTopology()
     : systemDetected(false), n_threads(0)
   {
-    mlog::boot.info("searching ACPI configuration...");
+    MLOG_INFO(mlog::boot, "searching ACPI configuration...");
 
     // find root system description pointer
     // QEMU seabios places RSDP somewhere in low mem and it is ACPI 1.0
     PhysPtr<uint16_t> ebdaBase(0x040E);
-    mlog::boot.detail("EBDA base", (void*)(size_t(*ebdaBase)<<4));
+    MLOG_DETAIL(mlog::boot, "EBDA base", (void*)(size_t(*ebdaBase)<<4));
 
     RSDP* rsdp = RSDP::find(PhysPtr<char>(0xe0000), 0x00100000-0xe0000);
     if (rsdp == 0) rsdp = RSDP::find(PhysPtr<char>(size_t(*ebdaBase)<<4), 4096);
-    mlog::boot.detail(DVAR(rsdp));
+    MLOG_DETAIL(mlog::boot, DVAR(rsdp));
     if (rsdp == 0 || rsdp->getRSDTPtr()==0) return;
 
     // parse the root system description table and search for the MADT
@@ -49,10 +49,10 @@ namespace mythos {
     MADT* madt = nullptr;
     for (size_t i = 0; i < rsdt->getNumSDTPtrs(); i++) {
       ACPI* entry = rsdt->getSDTPtr(i);
-      mlog::boot.detail("RSDT entry", DVARhex(entry->signature), DVAR(entry));
+      MLOG_DETAIL(mlog::boot, "RSDT entry", DVARhex(entry->signature), DVAR(entry));
       if (entry->signature == ACPI::MADT) madt = static_cast<MADT*>(entry);
     }
-    mlog::boot.detail("parsing MADT entries ...", DVAR(madt));
+    MLOG_DETAIL(mlog::boot, "parsing MADT entries ...", DVAR(madt));
     if (madt == nullptr) return;
 
     // parse the madt
@@ -90,7 +90,7 @@ namespace mythos {
       }
       } // switch
     }
-    mlog::boot.detail("found apic IDs", DVAR(n_threads));
+    MLOG_DETAIL(mlog::boot, "found apic IDs", DVAR(n_threads));
     systemDetected = true;
   }
 

--- a/kernel/boot/apboot-common/boot/DeployHWThread.hh
+++ b/kernel/boot/apboot-common/boot/DeployHWThread.hh
@@ -80,11 +80,11 @@ struct DeployHWThread
     gdt.kernel_gs.setBaseAddress(uint32_t(KernelCLM::getOffset(apicID)));
     async::preparePlace(apicID);
 
-    mlog::boot.detail("  mapped kernel stack", DVAR(apicID),
+    MLOG_DETAIL(mlog::boot, "  mapped kernel stack", DVAR(apicID),
                       (void*)stacks[apicID], (void*)(uintptr_t(stackspace)+apicID*CORE_STACK_SIZE-VIRT_ADDR));
-    mlog::boot.detail("  nmi stack", DVAR(apicID),
+    MLOG_DETAIL(mlog::boot, "  nmi stack", DVAR(apicID),
                       (void*)tss_kernel.ist[1]);
-    mlog::boot.detail("  core-local memory offset", DVAR(apicID),
+    MLOG_DETAIL(mlog::boot, "  core-local memory offset", DVAR(apicID),
                       (void*)(KernelCLM::getOffset(apicID)));
   }
 
@@ -93,7 +93,7 @@ struct DeployHWThread
     gdt.tss_kernel_load();
     KernelCLM::initOffset(apicID);
     cpu::initHWThreadID(apicID);
-    mlog::boot.detail("init", DVAR(apicID)); // no logging before the local CLM init
+    MLOG_DETAIL(mlog::boot, "init", DVAR(apicID)); // no logging before the local CLM init
     cpu::initSyscallEntry(stacks[apicID]);
     idt.load();
     async::initLocalPlace(apicID);

--- a/kernel/boot/apboot-mp/boot/MPApicTopology.hh
+++ b/kernel/boot/apboot-mp/boot/MPApicTopology.hh
@@ -140,17 +140,17 @@ namespace mythos {
   {
   public:
     MPApicTopology() {
-      mlog::boot.info("searching IntelMP structure...");
+      MLOG_INFO(mlog::boot, "searching IntelMP structure...");
       IntelMP::FPStructure* fp= findMP(PhysPtr<char>(0x0f0000ul).log(),0x0fffff-0x0f0000);
       ASSERT(fp);
-      mlog::boot.detail("MP floating pointer base:", fp);
-      mlog::boot.detail("MP floating spezification version:", fp->specRev);
+      MLOG_DETAIL(mlog::boot, "MP floating pointer base:", fp);
+      MLOG_DETAIL(mlog::boot, "MP floating spezification version:", fp->specRev);
 
       // find config table and local apics in base entries
       IntelMP::ConfigurationTable* configTable = fp->configuration_table.log();
-      mlog::boot.detail("MP configuration spezification version:", configTable->specRev);
-      mlog::boot.detail("MP configuration base length:", configTable->base_table_length);
-      mlog::boot.detail("MP configuration entry count:", configTable->entry_count);
+      MLOG_DETAIL(mlog::boot, "MP configuration spezification version:", configTable->specRev);
+      MLOG_DETAIL(mlog::boot, "MP configuration base length:", configTable->base_table_length);
+      MLOG_DETAIL(mlog::boot, "MP configuration entry count:", configTable->entry_count);
 
       uintptr_t baseEntries = uintptr_t(configTable) + sizeof(IntelMP::ConfigurationTable);
       uint16_t entry_count = 0;
@@ -159,7 +159,7 @@ namespace mythos {
         auto entry = reinterpret_cast<IntelMP::BaseEntry*>(baseEntries+pos);
         switch (entry->type){
           case PROCESSOR: {
-            //mlog::boot.detail("PROCESSOR table entry at offset", pos);
+            //MLOG_DETAIL(mlog::boot, "PROCESSOR table entry at offset", pos);
             auto proc_entry = static_cast<IntelMP::EntryProcessor*>(entry);
             if (proc_entry->flags & 0x01) {  // processor is usuable
               lapicIDs[num_threads] = proc_entry->local_apic_id;
@@ -170,7 +170,7 @@ namespace mythos {
             break;
           }
           default:
-            //mlog::boot.detail("invalid table type", entry->type,"at offset", pos);
+            //MLOG_DETAIL(mlog::boot, "invalid table type", entry->type,"at offset", pos);
             pos+=8;
             entry_count++;
             break;

--- a/kernel/boot/cxx-globals/boot/cxx-globals.hh
+++ b/kernel/boot/cxx-globals/boot/cxx-globals.hh
@@ -36,10 +36,10 @@ namespace boot {
   inline void initCxxGlobals()
   {
     // initialize global variables by calling their constructors
-    mlog::boot.detail("Calling constructors of all static instances");
+    MLOG_DETAIL(mlog::boot, "Calling constructors of all static instances");
     for (void (**func)() = &CTORS_START; func != &CTORS_END; func++) {
       if (*func == 0) break;
-      mlog::boot.detail("calling constructor", DVAR((void*)size_t(*func)));
+      MLOG_DETAIL(mlog::boot, "calling constructor", DVAR((void*)size_t(*func)));
       (*func)();
     }
   }

--- a/kernel/boot/kernel-main/boot/kernel.cc
+++ b/kernel/boot/kernel-main/boot/kernel.cc
@@ -90,9 +90,9 @@ NORETURN void runUser();
 
 void runUser() {
   mythos::async::getLocalPlace().processTasks();
-  mlog::boot.detail("trying to execute app");
+  MLOG_DETAIL(mlog::boot, "trying to execute app");
   mythos::boot::getLocalScheduler().tryRunUser();
-  mlog::boot.detail("going to sleep now");
+  MLOG_DETAIL(mlog::boot, "going to sleep now");
   mythos::cpu::go_sleeping(); // resets the kernel stack!
 }
 
@@ -100,7 +100,7 @@ void entry_ap(size_t id)
 {
   //asm volatile("xchg %bx,%bx");
   mythos::boot::apboot_thread(id);
-  mlog::boot.detail("started hardware thread");
+  MLOG_DETAIL(mlog::boot, "started hardware thread");
 
   if (id == mythos::cpu::enumerateHwThreadID(0)) {
     auto res = mythos::boot::load_init(); // start the first application
@@ -113,14 +113,14 @@ void entry_ap(size_t id)
 void mythos::cpu::sleeping_failed()
 {
   mythos::async::getLocalPlace().enterKernel();
-  mlog::boot.detail("sleeping failed without visible interrupt");
+  MLOG_DETAIL(mlog::boot, "sleeping failed without visible interrupt");
   runUser();
 }
 
 void mythos::cpu::syscall_entry_cxx(mythos::cpu::ThreadState* ctx)
 {
   mythos::async::getLocalPlace().enterKernel();
-  mlog::boot.detail("user system call", DVAR(ctx->rdi), DVAR(ctx->rsi),
+  MLOG_DETAIL(mlog::boot, "user system call", DVAR(ctx->rdi), DVAR(ctx->rsi),
       DVARhex(ctx->rip), DVARhex(ctx->rsp));
   mythos::handle_syscall(ctx);
   runUser();
@@ -129,7 +129,7 @@ void mythos::cpu::syscall_entry_cxx(mythos::cpu::ThreadState* ctx)
 void mythos::cpu::irq_entry_user(mythos::cpu::ThreadState* ctx)
 {
   mythos::async::getLocalPlace().enterKernel();
-  mlog::boot.detail("user interrupt", DVAR(ctx->irq), DVAR(ctx->error),
+  MLOG_DETAIL(mlog::boot, "user interrupt", DVAR(ctx->irq), DVAR(ctx->error),
       DVARhex(ctx->rip), DVARhex(ctx->rsp));
   if (ctx->irq<32) {
     mythos::handle_trap(ctx); // handle traps, exceptions, bugs from user mode
@@ -142,14 +142,14 @@ void mythos::cpu::irq_entry_user(mythos::cpu::ThreadState* ctx)
 
 void mythos::cpu::irq_entry_kernel(mythos::cpu::KernelIRQFrame* ctx)
 {
-  mlog::boot.detail("kernel interrupt", DVAR(ctx->irq), DVAR(ctx->error),
+  MLOG_DETAIL(mlog::boot, "kernel interrupt", DVAR(ctx->irq), DVAR(ctx->error),
       DVARhex(ctx->rip), DVARhex(ctx->rsp));
   bool wasbug = handle_bugirqs(ctx);
   bool nested = mythos::async::getLocalPlace().enterKernel();
   // initiate irq processing: first kernel bugs
   if (!wasbug) {
     // TODO then external and wakeup interrupts
-    mlog::boot.info("ack the interrupt");
+    MLOG_INFO(mlog::boot, "ack the interrupt");
     mythos::lapic.endOfInterrupt();
   }
 

--- a/kernel/boot/kmem-common/boot/kmem-common.hh
+++ b/kernel/boot/kmem-common/boot/kmem-common.hh
@@ -52,13 +52,13 @@ namespace mythos {
       }
 
       void reserve(size_t begin, size_t end, const char* reason) {
-        mlog::boot.detail("reserve", DMRANGE(begin, end-begin), "for", reason);
+        MLOG_DETAIL(mlog::boot, "reserve", DMRANGE(begin, end-begin), "for", reason);
         this->substract(begin, end);
       }
 
       void addToUM(UntypedMemory& um) {
         for (auto& r : *this) {
-          mlog::boot.detail("add range", DMRANGE(r.getStart(), r.getSize()), "to untyped memory");
+          MLOG_DETAIL(mlog::boot, "add range", DMRANGE(r.getStart(), r.getSize()), "to untyped memory");
           um.addRange(PhysPtr<void>(r.getStart()), r.getSize());
         }
       }

--- a/kernel/boot/kmem-e820/boot/kmem.cc
+++ b/kernel/boot/kmem-e820/boot/kmem.cc
@@ -39,10 +39,10 @@ void initKernelMemory(UntypedMemory& um)
   E820Info ebi;
   OOPS_MSG(ebi.size()>0, "No Linux zero page E820 memory map found! :(");
   if (ebi.size() > 0) {
-    mlog::boot.info("load Linux zero page E820 memory map with size", ebi.size());
+    MLOG_INFO(mlog::boot, "load Linux zero page E820 memory map with size", ebi.size());
     for (size_t i=0; i < ebi.size(); i++) {
       auto me = ebi[i];
-      mlog::boot.detail("E820 mmap ", DMRANGE(me.addr.physint(), me.size),
+      MLOG_DETAIL(mlog::boot, "E820 mmap ", DMRANGE(me.addr.physint(), me.size),
 			(me.isUsable() ? "available" : "reserved"));
       if (me.isUsable()) usable_mem.addStartLength(me.addr, me.size);
     }

--- a/kernel/boot/kmem-multiboot/boot/kmem.cc
+++ b/kernel/boot/kmem-multiboot/boot/kmem.cc
@@ -46,10 +46,10 @@ void initKernelMemory(UntypedMemory& um)
 
   // find usable RAM areas and add them to the memory pool
   OOPS_MSG(mboot_magic == MultiBoot::MAGIC, "No MultiBoot memory map found :(");
-  mlog::boot.detail("multiboot table: ", DVARhex(mboot_magic), DVARhex(mboot_table));
+  MLOG_DETAIL(mlog::boot, "multiboot table: ", DVARhex(mboot_magic), DVARhex(mboot_table));
   if (mboot_magic == MultiBoot::MAGIC) {
     mbi.foreach([&usable_mem](MultiBootInfo::MMapEntry const* me) {
-      mlog::boot.detail("MB mmap ", DMRANGE(me->getAddress().physint(), me->getSize()),
+      MLOG_DETAIL(mlog::boot, "MB mmap ", DMRANGE(me->getAddress().physint(), me->getSize()),
        (me->isAvailable() ? " available " : (me->isReserved() ? " reserved " : "NA")));
       if (me->isAvailable())
 	      usable_mem.addStartLength(me->getAddress(), me->getSize());

--- a/kernel/boot/kmem-sfi/boot/kmem.cc
+++ b/kernel/boot/kmem-sfi/boot/kmem.cc
@@ -42,11 +42,11 @@ void initKernelMemory(UntypedMemory& um)
   OOPS_MSG(info.hasSyst() && info.hasMmap(), "No memory map found :(");
   if (info.hasSyst() && info.hasMmap()) {
     SFI::Mmap& mmap = *info.getMmap();
-    mlog::boot.detail("parsing SFI System Table", DVAR(&mmap));
+    MLOG_DETAIL(mlog::boot, "parsing SFI System Table", DVAR(&mmap));
 
     for(unsigned j=0; j<mmap.size(); ++j) {
       auto me = mmap[j];
-      mlog::boot.detail("MB mmap ", DMRANGE(me.getAddress().physint(), me.getSize()),
+      MLOG_DETAIL(mlog::boot, "MB mmap ", DMRANGE(me.getAddress().physint(), me.getSize()),
           (me.type == SFI::Mmap::ConventionalMemory ? " available " : "reserved"));
       if (me.type == SFI::Mmap::ConventionalMemory)
         usable_mem.addStartLength(me.getAddress(), me.getSize());

--- a/kernel/cpu/kernel-bug-amd64/cpu/IrqHandler.cc
+++ b/kernel/cpu/kernel-bug-amd64/cpu/IrqHandler.cc
@@ -38,19 +38,19 @@ namespace mythos {
   {
   public:
     void process(cpu::KernelIRQFrame* ctx) {
-      mlog::boot.error("kernel fault", DVAR(ctx->irq), DVAR(ctx->error),
+      MLOG_ERROR(mlog::boot, "kernel fault", DVAR(ctx->irq), DVAR(ctx->error),
 		       DVARhex(x86::getCR2()));
-      mlog::boot.error("...", DVARhex(ctx->rip), DVAR(ctx->cs), DVARhex(ctx->rflags),
+      MLOG_ERROR(mlog::boot, "...", DVARhex(ctx->rip), DVAR(ctx->cs), DVARhex(ctx->rflags),
 		       DVARhex(ctx->rsp), DVAR(ctx->ss));
-      mlog::boot.error("...", DVARhex(ctx->rax), DVARhex(ctx->rbx), DVARhex(ctx->rcx),
+      MLOG_ERROR(mlog::boot, "...", DVARhex(ctx->rax), DVARhex(ctx->rbx), DVARhex(ctx->rcx),
 		       DVARhex(ctx->rdx), DVARhex(ctx->rbp), DVARhex(ctx->rdi),
 		       DVARhex(ctx->rsi));
-      mlog::boot.error("...", DVARhex(ctx->r8), DVARhex(ctx->r9), DVARhex(ctx->r10),
+      MLOG_ERROR(mlog::boot, "...", DVARhex(ctx->r8), DVARhex(ctx->r9), DVARhex(ctx->r10),
 		       DVARhex(ctx->r11), DVARhex(ctx->r12), DVARhex(ctx->r13),
 		       DVARhex(ctx->r14), DVARhex(ctx->r15));
-      mlog::boot.error("stacktrace:");
+      MLOG_ERROR(mlog::boot, "stacktrace:");
       for (auto& frame : StackTrace(ctx->rbp)) {
-	mlog::boot.error('\t', frame.ret);
+	MLOG_ERROR(mlog::boot, '\t', frame.ret);
       }
       // TODO information from interesting kernel data structures
       mythos::sleep_infinitely();
@@ -62,7 +62,7 @@ namespace mythos {
   {
   public:
     void process(cpu::KernelIRQFrame* ctx) {
-      mlog::boot.info("kernel irq", DVAR(ctx->irq), DVAR(ctx->error),
+      MLOG_INFO(mlog::boot, "kernel irq", DVAR(ctx->irq), DVAR(ctx->error),
 		      DVARhex(ctx->rip), DVARhex(ctx->rsp));
     }
   };

--- a/kernel/cpu/kernel-entry-amd64/cpu/IdtAmd64.cc
+++ b/kernel/cpu/kernel-entry-amd64/cpu/IdtAmd64.cc
@@ -39,7 +39,7 @@ namespace mythos {
   }
   
   void IdtAmd64::init() {
-    mlog::boot.detail("init IDT with entry handlers at", (void*)interrupt_entry_table[0]);
+    MLOG_DETAIL(mlog::boot, "init IDT with entry handlers at", (void*)interrupt_entry_table[0]);
     initEarly();
     // mark interrupts that shall be executed on the nmi stack
     table[2].setIST(1); // NMI Non-Maskable Interrupt

--- a/kernel/host/pci-memaccess/host/MemAccess.hh
+++ b/kernel/host/pci-memaccess/host/MemAccess.hh
@@ -42,7 +42,7 @@ namespace mythos {
     {
       std::cout << "map " << (void*)paddr.physint() << " size " << msize 
 		<< " laddr " << laddr << std::endl;
-      // mlog::mmu.detail("temp. map", DVARhex(paddr), DVARhex(laddr), DVAR(msize));
+      // MLOG_DETAIL(mlog::mmu, "temp. map", DVARhex(paddr), DVARhex(laddr), DVAR(msize));
     }
 
     MemAccess(MemAccess&& o)
@@ -62,7 +62,7 @@ namespace mythos {
     ~MemAccess() {
       if (mapper != 0) {
 	mapper->unmap(laddr, msize);
-	// mlog::mmu.detail("temp. unmap", DVARhex(laddr), DVAR(msize));
+	// MLOG_DETAIL(mlog::mmu, "temp. unmap", DVARhex(laddr), DVAR(msize));
       }
     }
 

--- a/kernel/objects/capability-common/objects/DeleteBroadcast.cc
+++ b/kernel/objects/capability-common/objects/DeleteBroadcast.cc
@@ -45,7 +45,7 @@ namespace mythos {
 
   void DeleteBroadcast::run(Tasklet* t, IResult<void>* res)
   {
-    mlog::cap.detail("start delete broadcast");
+    MLOG_DETAIL(mlog::cap, "start delete broadcast");
     DeleteBroadcast* start = &nodes[cpu::hwThreadID()];
     start->broadcast(t, res, start);
   }
@@ -55,10 +55,10 @@ namespace mythos {
     DeleteBroadcast* pnext = this->next;
     while (pnext != start && !pnext->home->isActive()) pnext = pnext->next;
     if (pnext != start) {
-      mlog::cap.detail("relay delete broadcast");
+      MLOG_DETAIL(mlog::cap, "relay delete broadcast");
       pnext->home->run(t->set( [=](Tasklet* t){ broadcast(t, res, start); } ));
     } else {
-      mlog::cap.detail("end delete broadcast");
+      MLOG_DETAIL(mlog::cap, "end delete broadcast");
       res->response(t);
     }
   }

--- a/kernel/objects/capability-common/objects/ops.cc
+++ b/kernel/objects/capability-common/objects/ops.cc
@@ -39,7 +39,7 @@ namespace mythos {
     // first check ranges
     auto parentRange = parent.getPtr()->addressRange(parent);
     auto otherRange = other.getPtr()->addressRange(other);
-    //mlog::cap.detail(DVAR(parentRange), DVAR(otherRange));
+    //MLOG_DETAIL(mlog::cap, DVAR(parentRange), DVAR(otherRange));
     if (parentRange.contains(otherRange)) {
 
       if (!otherRange.contains(parentRange)) {
@@ -64,7 +64,7 @@ namespace mythos {
 
   optional<void> inherit(CapEntry& thisEntry, CapEntry& newEntry, Cap thisCap, Cap newCap)
   {
-    mlog::cap.detail("inherit caps", DVAR(thisCap), DVAR(newCap),
+    MLOG_DETAIL(mlog::cap, "inherit caps", DVAR(thisCap), DVAR(newCap),
 		    DVAR(isParentOf(thisCap, newCap)), DVAR(isParentOf(newCap, thisCap)));
     ASSERT(newEntry.cap().isAllocated());
     ASSERT(implies(thisCap.isReference(), !isParentOf(thisCap, newCap) && !isParentOf(newCap, thisCap)));

--- a/kernel/objects/capability-spinning/objects/CapEntry.cc
+++ b/kernel/objects/capability-spinning/objects/CapEntry.cc
@@ -118,7 +118,7 @@ namespace mythos {
     Cap curCap;
     do {
       curCap = Cap(expected);
-      mlog::cap.detail(this, ".kill", DVAR(curCap));
+      MLOG_DETAIL(mlog::cap, this, ".kill", DVAR(curCap));
       if (!curCap.isUsable()) {
         return curCap.isZombie() ? true : false;
       }

--- a/kernel/objects/capability-spinning/objects/RevokeOperation.cc
+++ b/kernel/objects/capability-spinning/objects/RevokeOperation.cc
@@ -68,7 +68,7 @@ namespace mythos {
       return;
     }
     if (!entry.kill()) {
-      mlog::cap.detail("Can not kill entry", &entry, entry);
+      MLOG_DETAIL(mlog::cap, "Can not kill entry", &entry, entry);
       res->response(t, Error::LOST_RACE);
       monitor.requestDone();
       return;

--- a/kernel/objects/capability-spinning/objects/RevokeOperation.hh
+++ b/kernel/objects/capability-spinning/objects/RevokeOperation.hh
@@ -63,7 +63,7 @@ public:
   void revokeCap(Tasklet* t, result_t* res, CapEntry& entry, IKernelObject* guarded)
   {
     monitor.request(t, [=, &entry](Tasklet* t) {
-      mlog::cap.error("revoke cap called");
+      MLOG_ERROR(mlog::cap, "revoke cap called");
       _revoke(t, res, entry, guarded);
     });
   }
@@ -71,7 +71,7 @@ public:
   void deleteCap(Tasklet* t, result_t* res, CapEntry& entry, IKernelObject* guarded)
   {
     monitor.request(t, [=, &entry](Tasklet* t) {
-      mlog::cap.error("delete cap called");
+      MLOG_ERROR(mlog::cap, "delete cap called");
       _delete(t, res, entry, guarded);
     });
   }
@@ -80,19 +80,19 @@ public:
   {
     ASSERT(res.isSuccess());
     monitor.response(t, [=](Tasklet* t) {
-        mlog::cap.detail("received broadcast or delete response");
+        MLOG_DETAIL(mlog::cap, "received broadcast or delete response");
         _deleteObject(t);
       });
   }
 
   bool acquire() {
     auto result = !_lock.test_and_set();
-    //mlog::cap.error("acquire ops =>", result);
+    //MLOG_ERROR(mlog::cap, "acquire ops =>", result);
     return result;
   }
 
   void release() {
-    //mlog::cap.error("release ops");
+    //MLOG_ERROR(mlog::cap, "release ops");
     _lock.clear();
   };
 

--- a/kernel/objects/memory/objects/PML4InvalidationBroadcast.cc
+++ b/kernel/objects/memory/objects/PML4InvalidationBroadcast.cc
@@ -46,7 +46,7 @@ namespace mythos {
 
   void PML4InvalidationBroadcast::run(Tasklet* t, IResult<void>* res, PhysPtr<void> pml4)
   {
-    mlog::cap.detail("start pml4 invalidation broadcast");
+    MLOG_DETAIL(mlog::cap, "start pml4 invalidation broadcast");
     PML4InvalidationBroadcast* start = &nodes[cpu::hwThreadID()];
     start->broadcast(t, res, pml4, start);
   }
@@ -62,10 +62,10 @@ namespace mythos {
     PML4InvalidationBroadcast* pnext = this->next;
     while (pnext != start && pnext->home->getCR3() != pml4) pnext = pnext->next;
     if (pnext != start) {
-      mlog::cap.detail("relay pml4 invalidation");
+      MLOG_DETAIL(mlog::cap, "relay pml4 invalidation");
       pnext->home->run(t->set( [=](Tasklet* t){ broadcast(t, res, pml4,  start); } ));
     } else {
-      mlog::cap.detail("end pml4 invalidation");
+      MLOG_DETAIL(mlog::cap, "end pml4 invalidation");
       res->response(t);
     }
   }

--- a/kernel/objects/portal/objects/Portal.cc
+++ b/kernel/objects/portal/objects/Portal.cc
@@ -39,7 +39,7 @@ namespace mythos {
 
   optional<void> Portal::setInvocationBuf(optional<CapEntry*> fe, uint32_t offset)
   {
-    mlog::portal.info("Portal::setInvocationBuf", DVAR(fe), DVAR(offset));
+    MLOG_INFO(mlog::portal, "Portal::setInvocationBuf", DVAR(fe), DVAR(offset));
     TypedCap<IFrame> frame(fe);
     if (!frame) return frame;
     auto info = frame.getFrameInfo();
@@ -51,19 +51,19 @@ namespace mythos {
 
   void Portal::bind(optional<IFrame*> obj)
   {
-    mlog::portal.info("Portal::setInvocationBuf bind");
+    MLOG_INFO(mlog::portal, "Portal::setInvocationBuf bind");
     if (obj) ib = ibNew;
   }
 
   void Portal::unbind(optional<IFrame*>)
   {
-    mlog::portal.info("Portal::setInvocationBuf unbind");
+    MLOG_INFO(mlog::portal, "Portal::setInvocationBuf unbind");
     ib = nullptr; // but do not overwrite ibNew before the bind() method!
   }
 
   optional<void> Portal::setOwner(optional<CapEntry*> ece, uintptr_t uctx)
   {
-    mlog::portal.info("Portal::setOwner", DVAR(ece), DVARhex(uctx));
+    MLOG_INFO(mlog::portal, "Portal::setOwner", DVAR(ece), DVARhex(uctx));
     TypedCap<IPortalUser> ec(ece);
     if (!ec) return ec;
     return _owner.set(this, *ece, ec.cap());
@@ -71,7 +71,7 @@ namespace mythos {
 
   void Portal::unbind(optional<IPortalUser*> obj)
   {
-    mlog::portal.info("Portal::setOwner unbind");
+    MLOG_INFO(mlog::portal, "Portal::setOwner unbind");
     if (obj) obj->denotify(&notificationHandle);
   }
 
@@ -91,7 +91,7 @@ namespace mythos {
 
   optional<void> Portal::sendInvocation(Cap self, CapPtr dest, uint64_t user)
   {
-    mlog::portal.info("Portal::sendInvocation", DVAR(self), DVAR(dest));
+    MLOG_INFO(mlog::portal, "Portal::sendInvocation", DVAR(self), DVAR(dest));
     TypedCap<IPortalUser> owner(_owner.cap());
     if (!owner) return owner.state();
     auto dref = owner->lookupRef(dest, 32, false);
@@ -111,7 +111,7 @@ namespace mythos {
 
   void Portal::replyResponse(optional<void> error)
   {
-    mlog::portal.info("Portal::replyResponse", DVAR(error.state()));
+    MLOG_INFO(mlog::portal, "Portal::replyResponse", DVAR(error.state()));
     ASSERT(portalState == INVOKING);
     currentDest.release();
     portalState = REPLYING;
@@ -124,7 +124,7 @@ namespace mythos {
 
   void Portal::deletionResponse(CapEntry* entry, bool delRoot)
   {
-    mlog::portal.info("Portal::deletionResponse", DVAR(delRoot));
+    MLOG_INFO(mlog::portal, "Portal::deletionResponse", DVAR(delRoot));
     ASSERT(portalState == INVOKING);
     currentDest.release();
     if (delRoot) {
@@ -136,7 +136,7 @@ namespace mythos {
 
   void Portal::response(Tasklet*, optional<void> res)
   {
-    mlog::portal.info("Portal::deletion response:", res.state());
+    MLOG_INFO(mlog::portal, "Portal::deletion response:", res.state());
     ASSERT(portalState == INVOKING);
     portalState = REPLYING;
     auto owner = _owner.get();
@@ -148,7 +148,7 @@ namespace mythos {
 
   optional<void> Portal::deleteCap(Cap self, IDeleter& del)
   {
-    mlog::portal.detail("delete cap", self);
+    MLOG_DETAIL(mlog::portal, "delete cap", self);
     if (self.isOriginal()) {
       if (!revokeOp.acquire()) {
         // we are currently deleting, so abort in order to prevent a deadlock
@@ -165,7 +165,7 @@ namespace mythos {
 
   void Portal::invoke(Tasklet* t, Cap self, IInvocation* msg)
   {
-    mlog::portal.info("Portal::invoke", DVAR(t), DVAR(self), DVAR(msg));
+    MLOG_INFO(mlog::portal, "Portal::invoke", DVAR(t), DVAR(self), DVAR(msg));
     monitor.request(t, [=](Tasklet* t){
         Error err = Error::NOT_IMPLEMENTED;
         switch (msg->getProtocol()) {

--- a/kernel/objects/scheduling-context/objects/SchedulingContext.cc
+++ b/kernel/objects/scheduling-context/objects/SchedulingContext.cc
@@ -36,14 +36,14 @@ namespace mythos {
 
   void SchedulingContext::unbind(handle_t* ec)
   {
-    mlog::sched.detail("unbind", ec);
+    MLOG_DETAIL(mlog::sched, "unbind", ec);
     readyQueue.remove(ec);
     preempt(ec); /// @todo race when ec is deleted too early
   }
 
   void SchedulingContext::ready(handle_t* ec)
   {
-    mlog::sched.info("ready", ec);
+    MLOG_INFO(mlog::sched, "ready", ec);
     ASSERT(ec != nullptr);
 
     readyQueue.remove(ec); /// @todo do not need to remove if already on the queue, just do nothing then
@@ -67,7 +67,7 @@ namespace mythos {
 
   void SchedulingContext::preempt(Tasklet* t, IResult<void>* res, handle_t* ec)
   {
-    mlog::sched.detail("preempt", DVAR(t), DVAR(ec));
+    MLOG_DETAIL(mlog::sched, "preempt", DVAR(t), DVAR(ec));
     ASSERT(ec != nullptr);
     handle_t* const removed = reinterpret_cast<handle_t*>(REMOVED);
     if (!current_ec.compare_exchange_strong(ec, removed))
@@ -76,7 +76,7 @@ namespace mythos {
     if (&getLocalPlace() == home)
       return res->response(t, Error::SUCCESS); // we are on the home thread already, nothing to do
     if (preempting.test_and_set()) return; // we are preempting the home already, nothing to do
-    mlog::sched.detail("send preemption message", DVAR(t), DVAR(home));
+    MLOG_DETAIL(mlog::sched, "send preemption message", DVAR(t), DVAR(home));
     home->run(tasklet.set([=](Tasklet* t){
           res->response(t, Error::SUCCESS);
           preempting.clear();
@@ -85,7 +85,7 @@ namespace mythos {
 
   void SchedulingContext::preempt(handle_t* ec)
   {
-    mlog::sched.detail("preempt", DVAR(ec));
+    MLOG_DETAIL(mlog::sched, "preempt", DVAR(ec));
     ASSERT(ec != nullptr);
     handle_t* const removed = reinterpret_cast<handle_t*>(REMOVED);
     if (!current_ec.compare_exchange_strong(ec, removed)) return; // was not selected, nothing to do
@@ -93,7 +93,7 @@ namespace mythos {
   }
 
   void SchedulingContext::preempt() {
-    mlog::sched.detail("preempt", DVAR(home));
+    MLOG_DETAIL(mlog::sched, "preempt", DVAR(home));
     if (&getLocalPlace() == home) return; // we are on the home thread already, nothing to do
     if (preempting.test_and_set()) return; // we are preempting the home already, nothing to do
     home->run(tasklet.set([=](Tasklet*){ preempting.clear(); }));
@@ -101,7 +101,7 @@ namespace mythos {
 
   void SchedulingContext::yield(handle_t* ec)
   {
-    mlog::sched.detail("yield", DVAR(ec));
+    MLOG_DETAIL(mlog::sched, "yield", DVAR(ec));
     ASSERT(ec != nullptr);
     if (current_ec != ec) return; // was not selected, nothing to do
     if (readyQueue.empty()) return; // no other waiting thread, nothing to do
@@ -114,7 +114,7 @@ namespace mythos {
 
   void SchedulingContext::tryRunUser()
   {
-    mlog::sched.detail("tryRunUser");
+    MLOG_DETAIL(mlog::sched, "tryRunUser");
     ASSERT(&getLocalPlace() == home);
     handle_t* current = current_ec;
     handle_t* const removed = reinterpret_cast<handle_t*>(REMOVED);

--- a/kernel/objects/untyped-memory/objects/UntypedMemory.cc
+++ b/kernel/objects/untyped-memory/objects/UntypedMemory.cc
@@ -49,11 +49,11 @@ optional<void*> UntypedMemory::alloc(size_t length, size_t alignment)
 {
   auto result = heap.alloc(length, alignment);
   if (result) {
-    mlog::um.info("alloc", DVAR(length), DVARhex(alignment), DVARhex(*result));
+    MLOG_INFO(mlog::um, "alloc", DVAR(length), DVARhex(alignment), DVARhex(*result));
     monitor.acquireRef();
     return reinterpret_cast<void*>(*result);
   } else {
-    mlog::um.info("alloc failed", DVAR(length), DVARhex(alignment), DVAR(result.state()));
+    MLOG_INFO(mlog::um, "alloc failed", DVAR(length), DVARhex(alignment), DVAR(result.state()));
     return result.state();
   }
 }
@@ -67,11 +67,11 @@ optional<void> UntypedMemory::alloc(MemoryDescriptor* begin, MemoryDescriptor* e
     ASSERT(!it->ptr);
     result = heap.alloc(it->size, it->alignment);
     if (result) {
-      mlog::um.info("alloc", DVAR(it->size), DVARhex(it->alignment), DVARhex(*result));
+      MLOG_INFO(mlog::um, "alloc", DVAR(it->size), DVARhex(it->alignment), DVARhex(*result));
       monitor.acquireRef();
       it->ptr = reinterpret_cast<void*>(*result);
     } else {
-      mlog::um.info("alloc failed", DVAR(it->size), DVARhex(it->alignment), DVAR(result.state()));
+      MLOG_INFO(mlog::um, "alloc failed", DVAR(it->size), DVARhex(it->alignment), DVAR(result.state()));
       break;
     }
   }
@@ -87,7 +87,7 @@ void UntypedMemory::free(void* ptr, size_t length)
 {
   auto start = reinterpret_cast<uintptr_t>(ptr);
   auto freeRange = Range<uintptr_t>::bySize(PhysPtr<void>::fromKernel(ptr).physint(), length);
-  mlog::um.info("free", DVARhex(ptr), DVARhex(length));
+  MLOG_INFO(mlog::um, "free", DVARhex(ptr), DVARhex(length));
   ASSERT(_range.contains(freeRange));
   monitor.releaseRef();
   heap.free(start, length);
@@ -115,7 +115,7 @@ void UntypedMemory::addRange(PhysPtr<void> start, size_t length)
 void UntypedMemory::free(Tasklet* t, IResult<void>* r,
        MemoryDescriptor* begin, MemoryDescriptor* end)
 {
-  mlog::um.info("free request", DVAR(t), DVAR(r), DVARhex(begin), DVARhex(end));
+  MLOG_INFO(mlog::um, "free request", DVAR(t), DVAR(r), DVARhex(begin), DVARhex(end));
   monitor.request(t, [=](Tasklet* t){
       this->free(begin, end);
       r->response(t);
@@ -125,7 +125,7 @@ void UntypedMemory::free(Tasklet* t, IResult<void>* r,
 
 void UntypedMemory::free(Tasklet* t, IResult<void>* r, void* start, size_t length)
 {
-  mlog::um.info("free request", DVAR(t), DVAR(r), DVARhex(start), DVARhex(length));
+  MLOG_INFO(mlog::um, "free request", DVAR(t), DVAR(r), DVARhex(start), DVARhex(length));
   monitor.request(t, [=](Tasklet* t){
       this->free(start, length);
       r->response(t);

--- a/kernel/plugins/test-places/plugins/test-places.cc
+++ b/kernel/plugins/test-places/plugins/test-places.cc
@@ -44,7 +44,7 @@ namespace mythos {
 
       void run() {
 	monitor.request(&starter, [=](Tasklet*) {
-	    mlog::boot.info("TestPlaces: started processing");
+	    MLOG_INFO(mlog::boot, "TestPlaces: started processing");
 	    state = 0;
 	    process();
 	  });
@@ -60,27 +60,27 @@ namespace mythos {
 	    return this->monitor.responseDone();
 	  case 1: ;
 	  }
-	  mlog::boot.info("TestPlaces: finished roundtrip");
+	  MLOG_INFO(mlog::boot, "TestPlaces: finished roundtrip");
 	  state = 2;
 	  return this->monitor.responseAndRequestDone();
 	default:
-	  mlog::boot.info("TestPlaces: strange call");
+	  MLOG_INFO(mlog::boot, "TestPlaces: strange call");
 	}
       }
 
       void fooRequest(Tasklet* t, Node* r) {
-	mlog::boot.info("TestPlaces: sending foo request", DVAR(t), DVAR(r), "to", DVAR(this));
+	MLOG_INFO(mlog::boot, "TestPlaces: sending foo request", DVAR(t), DVAR(r), "to", DVAR(this));
 	monitor.request(t, [=](Tasklet*t) { this->_fooRequest(t,r); } );
       }
 
       void _fooRequest(Tasklet* t, Node* r) {
-	mlog::boot.info("TestPlaces: process foo request", DVAR(t), DVAR(r), "on", DVAR(this));
+	MLOG_INFO(mlog::boot, "TestPlaces: process foo request", DVAR(t), DVAR(r), "on", DVAR(this));
 	r->fooResponse(t);
 	monitor.requestDone();
       }
 
       void fooResponse(Tasklet*t) {
-	mlog::boot.info("TestPlaces: sending foo response", DVAR(t), "to", DVAR(this));
+	MLOG_INFO(mlog::boot, "TestPlaces: sending foo response", DVAR(t), "to", DVAR(this));
 	monitor.response(t, [=](Tasklet*) { this->process(); });
       }
       
@@ -101,7 +101,7 @@ namespace mythos {
     }
 
     void initThread(size_t threadid) {
-      mlog::boot.detail("TestPlaces: my place is", &mythos::async::getLocalPlace(),
+      MLOG_DETAIL(mlog::boot, "TestPlaces: my place is", &mythos::async::getLocalPlace(),
 			threadid, cpu::enumerateHwThreadID(0),
 			cpu::hwThreadCount());
       if (threadid == cpu::enumerateHwThreadID(0)) {

--- a/kernel/util/mlog-base/util/Logger.hh
+++ b/kernel/util/mlog-base/util/Logger.hh
@@ -34,14 +34,22 @@ namespace mlog {
 
   extern ISink* sink;
 
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+#define PATH "[" __FILE__ ":" TOSTRING(__LINE__) "]"
+
 #define MLOG_DETAIL(logger, ...) \
-  if ((logger).isActive(mlog::TextDetail::VERBOSITY)) logger.write<mlog::TextDetail>(__VA_ARGS__);
+  if ((logger).isActive(mlog::TextDetail::VERBOSITY)) logger.write<mlog::TextDetail>( \
+          PATH, __VA_ARGS__);
 #define MLOG_INFO(logger, ...) \
-  if ((logger).isActive(mlog::TextInfo::VERBOSITY)) logger.write<mlog::TextInfo>(__VA_ARGS__);
+  if ((logger).isActive(mlog::TextInfo::VERBOSITY)) logger.write<mlog::TextInfo>( \
+         PATH, __VA_ARGS__);
 #define MLOG_WARN(logger, ...) \
-  if ((logger).isActive(mlog::TextWarn::VERBOSITY)) logger.write<mlog::TextWarn>(__VA_ARGS__);
+  if ((logger).isActive(mlog::TextWarn::VERBOSITY)) logger.write<mlog::TextWarn>( \
+          PATH, __VA_ARGS__);
 #define MLOG_ERROR(logger, ...) \
-  if ((logger).isActive(mlog::TextError::VERBOSITY)) logger.write<mlog::TextError>(__VA_ARGS__);
+  if ((logger).isActive(mlog::TextError::VERBOSITY)) logger.write<mlog::TextError>( \
+          PATH, __VA_ARGS__);
   
   template<class Filter=FilterAny>
   class Logger

--- a/kernel/util/plugins/util/Plugin.hh
+++ b/kernel/util/plugins/util/Plugin.hh
@@ -45,14 +45,14 @@ namespace mythos {
 
     static void initPluginsGlobal() {
       for (Plugin* c = first; c != nullptr; c = c->next) {
-	mlog::boot.info("initPluginsGlobal", c);
+	MLOG_INFO(mlog::boot, "initPluginsGlobal", c);
 	c->initGlobal();
       }
     }
 
     static void initPluginsOnThread(size_t threadid) {
       for (Plugin* c = first; c != nullptr; c = c->next) {
-	mlog::boot.info("initPluginsOnThread", c, threadid);
+	MLOG_INFO(mlog::boot, "initPluginsOnThread", c, threadid);
 	c->initThread(threadid);
       }
     }


### PR DESCRIPTION
This pull request changes all occurrences of the old mlog::boot.info(...) style to the new MLOG_INFO(mlog::boot, ...) style. This is meant to reduce the overhead when logging is turned off and unifies the usage of logging.