### PR TITLE
idle management hooks

### DIFF
--- a/3rdparty/mcconf/mcconf.py
+++ b/3rdparty/mcconf/mcconf.py
@@ -419,7 +419,7 @@ class Configuration:
 
         if resolveDeps:
             additionalMods = self.resolveDependencies()
-            names = ", ".join([m.name for m in additionalMods])
+            names = ", ".join(sorted([m.name for m in additionalMods]))
             logging.info('added modules to resolve dependencies: %s', names)
 
         missingRequires = self.getMissingRequires()

--- a/kernel-knc.config
+++ b/kernel-knc.config
@@ -27,4 +27,5 @@
       "plugin-dump-multiboot",
       "plugin-cpudriver-knc",
       "app-init-example",
+      "kernel-idle-knc",
     ]

--- a/kernel/app/init-example/app/init.cc
+++ b/kernel/app/init-example/app/init.cc
@@ -185,13 +185,13 @@ int main()
                            thread1stack_top, &thread_main, nullptr).wait();
     TEST(res1);
     MLOG_INFO(mlog::app, "test_EC: create ec2");
-    auto res2 = ec2.create(pl, kmem, myAS, myCS, mythos::init::SCHEDULERS_START+4,
+    auto res2 = ec2.create(pl, kmem, myAS, myCS, mythos::init::SCHEDULERS_START+1,
                            thread2stack_top, &thread_main, nullptr).wait();
     TEST(res2);
   }
 
   for (volatile int i=0; i<100000; i++) {
-    for (volatile int j=0; j<3000; j++) {}
+    for (volatile int j=0; j<1000; j++) {}
   }
 
   MLOG_INFO(mlog::app, "sending notifications");

--- a/kernel/app/init-example/app/init.cc
+++ b/kernel/app/init-example/app/init.cc
@@ -185,13 +185,13 @@ int main()
                            thread1stack_top, &thread_main, nullptr).wait();
     TEST(res1);
     MLOG_INFO(mlog::app, "test_EC: create ec2");
-    auto res2 = ec2.create(pl, kmem, myAS, myCS, mythos::init::SCHEDULERS_START+1,
+    auto res2 = ec2.create(pl, kmem, myAS, myCS, mythos::init::SCHEDULERS_START+4,
                            thread2stack_top, &thread_main, nullptr).wait();
     TEST(res2);
   }
 
   for (volatile int i=0; i<100000; i++) {
-    for (volatile int j=0; j<1000; j++) {}
+    for (volatile int j=0; j<3000; j++) {}
   }
 
   MLOG_INFO(mlog::app, "sending notifications");

--- a/kernel/boot/apboot-acpi/boot/apboot.cc
+++ b/kernel/boot/apboot-acpi/boot/apboot.cc
@@ -38,8 +38,8 @@ namespace mythos {
 
 DeployHWThread ap_config[BOOT_MAX_THREADS]; //< AP configuration objects index by APIC ID
 
-    NORETURN extern void start_ap64() SYMBOL("_start_ap64");
-    
+    NORETURN extern void start_ap64(size_t reason) SYMBOL("_start_ap64");
+
 NORETURN void apboot() {
   // read acpi topology, then initialise HWThread objects
   ACPIApicTopology topo;
@@ -57,12 +57,12 @@ NORETURN void apboot() {
   mythos::lapic.broadcastStartupIPI(0x40000);
 
   // switch to BSP's stack here
-  start_ap64(); // will never return from here!
+  start_ap64(0); // will never return from here!
 }
 
     void apboot_thread(size_t apicID) {
       ap_config[apicID].initThread(apicID);
     }
-    
+
   } // namespace boot
 } // namespace mythos

--- a/kernel/boot/apboot-acpi/boot/apboot.cc
+++ b/kernel/boot/apboot-acpi/boot/apboot.cc
@@ -61,7 +61,7 @@ NORETURN void apboot() {
 }
 
     void apboot_thread(size_t apicID) {
-      ap_config[apicID].initThread();
+      ap_config[apicID].initThread(apicID);
     }
     
   } // namespace boot

--- a/kernel/boot/apboot-common/boot/DeployHWThread.hh
+++ b/kernel/boot/apboot-common/boot/DeployHWThread.hh
@@ -92,7 +92,6 @@ struct DeployHWThread
     localScheduler.setAt(threadID, &getScheduler(threadID));
     getScheduler(threadID).init(async::getPlace(threadID));
     cpu::initSyscallStack(threadID, stacks[apicID]);
-    idle::init_thread(threadID);
     MLOG_DETAIL(mlog::boot, "  hw thread", DVAR(threadID), DVAR(apicID),
                 DVARhex(stacks[apicID]), DVARhex(stackphys), DVARhex(tss_kernel.ist[1]),
                 DVARhex(KernelCLM::getOffset(threadID)));
@@ -106,6 +105,7 @@ struct DeployHWThread
     // no logging before loading the GDT for the core-local memory
     idt.load();
     cpu::initSyscallEntry();
+    idle::init_thread();
 
     if (UNLIKELY(this->firstboot)) {
       mythos::lapic.init();

--- a/kernel/boot/apboot-common/boot/DeployHWThread.hh
+++ b/kernel/boot/apboot-common/boot/DeployHWThread.hh
@@ -89,6 +89,7 @@ struct DeployHWThread
   }
 
   void initThread(size_t apicID) {
+    loadKernelSpace();
     gdt.load();
     gdt.tss_kernel_load();
 

--- a/kernel/boot/apboot-common/boot/DeployHWThread.hh
+++ b/kernel/boot/apboot-common/boot/DeployHWThread.hh
@@ -93,7 +93,6 @@ struct DeployHWThread
     gdt.tss_kernel_load();
 
     if (UNLIKELY(this->firstboot)) {
-      /// @todo all the memory initialisation can be moved to prepare actually! this would remove this special case
       KernelCLM::initOffset(apicID);
       cpu::initHWThreadID(apicID);
       cpu::initSyscallEntry(stacks[apicID]);
@@ -107,7 +106,7 @@ struct DeployHWThread
     } else {
       cpu::initSyscallEntry();
       idt.load();
-      mythos::lapic.init(); /// @todo need lapic.init after deep sleep?
+      // not needed: mythos::lapic.init();
     }
   }
 

--- a/kernel/boot/apboot-mp/boot/apboot.cc
+++ b/kernel/boot/apboot-mp/boot/apboot.cc
@@ -38,7 +38,7 @@ namespace mythos {
 
 DeployHWThread ap_config[BOOT_MAX_THREADS]; //< AP configuration objects index by APIC ID
 
-    NORETURN extern void start_ap64() SYMBOL("_start_ap64");
+    NORETURN extern void start_ap64(size_t reason) SYMBOL("_start_ap64");
 
 NORETURN void apboot() {
   // read acpi topology, then initialise HWThread objects
@@ -57,7 +57,7 @@ NORETURN void apboot() {
   mythos::lapic.broadcastStartupIPI(0x40000);
 
   // switch to BSP's stack here
-  start_ap64(); // will never return from here!
+  start_ap64(0); // will never return from here!
 }
 
     void apboot_thread(size_t apicID) {

--- a/kernel/boot/apboot-mp/boot/apboot.cc
+++ b/kernel/boot/apboot-mp/boot/apboot.cc
@@ -39,7 +39,7 @@ namespace mythos {
 DeployHWThread ap_config[BOOT_MAX_THREADS]; //< AP configuration objects index by APIC ID
 
     NORETURN extern void start_ap64() SYMBOL("_start_ap64");
-    
+
 NORETURN void apboot() {
   // read acpi topology, then initialise HWThread objects
   MPApicTopology topo;
@@ -61,8 +61,8 @@ NORETURN void apboot() {
 }
 
     void apboot_thread(size_t apicID) {
-      ap_config[apicID].initThread();
+      ap_config[apicID].initThread(apicID);
     }
-    
+
   } // namespace boot
 } // namespace mythos

--- a/kernel/boot/apboot-sfi/boot/apboot.cc
+++ b/kernel/boot/apboot-sfi/boot/apboot.cc
@@ -37,7 +37,7 @@ namespace boot {
 
 DeployHWThread ap_config[BOOT_MAX_THREADS]; //< AP configuration objects index by APIC ID
 
-NORETURN extern void start_ap64() SYMBOL("_start_ap64");
+NORETURN extern void start_ap64(size_t reason) SYMBOL("_start_ap64");
 
 NORETURN void apboot()
 {
@@ -57,7 +57,7 @@ NORETURN void apboot()
   mythos::lapic.broadcastStartupIPI(0x40000);
 
   // switch to BSP's stack here
-  start_ap64(); // will never return from here!
+  start_ap64(0); // will never return from here!
 }
 
     void apboot_thread(size_t apicID) {

--- a/kernel/boot/apboot-sfi/boot/apboot.cc
+++ b/kernel/boot/apboot-sfi/boot/apboot.cc
@@ -61,7 +61,7 @@ NORETURN void apboot()
 }
 
     void apboot_thread(size_t apicID) {
-      ap_config[apicID].initThread();
+      ap_config[apicID].initThread(apicID);
     }
 
   } // namespace boot

--- a/kernel/boot/init-loader-amd64/boot/load_init.cc
+++ b/kernel/boot/init-loader-amd64/boot/load_init.cc
@@ -48,8 +48,9 @@
 namespace mythos {
   extern KernelMemory* kmem_root();
   namespace boot {
+    using namespace mythos::init;
 
-  using namespace mythos::init;
+InitLoaderPlugin initloaderplugin;
 
 extern char app_image_start SYMBOL("app_image_start");
 

--- a/kernel/boot/init-loader-amd64/boot/load_init.hh
+++ b/kernel/boot/init-loader-amd64/boot/load_init.hh
@@ -102,5 +102,17 @@ namespace mythos {
      */
     optional<void> load_init();
 
+    /** create the root task EC on the first hardware thread */
+    class InitLoaderPlugin
+      : public Plugin
+    {
+    public:
+      virtual ~InitLoaderPlugin() {}
+      void initThread(size_t apicID) {
+        if (apicID == cpu::enumerateHwThreadID(0))
+          OOPS(mythos::boot::load_init()); // start the first application
+      }
+    };
+
   } // namespace boot
 } // namespace mythos

--- a/kernel/boot/kernel-amd64-knc/boot/start.S
+++ b/kernel/boot/kernel-amd64-knc/boot/start.S
@@ -96,7 +96,7 @@ _mboot_header:
         .long MULTIBOOT_HEADER_FLAGS
         .long -(MULTIBOOT_HEADER_MAGIC+MULTIBOOT_HEADER_FLAGS)
 
-/** Global Descriptor Table (GDT) during boot wiht five segments.
+/** Global Descriptor Table (GDT) during boot.
  * see 3.4.5.1 Code- and Data-Segment Descriptor Types in Intel 253668-048US.
  * granularity 0xa0 = 10100000b => limit granularity 4kb, operand size unset, 64bit mode
  * access 0x9b = 10011011b => present, ring0, code/data, Execute/Read accessed
@@ -105,7 +105,7 @@ _mboot_header:
  *  1011 execute/read accessed
  *  access 0xfb = 11111011 => present, ring3, code/data, Execute/Read accessed
  *  limit can be 0 because it is not used in 64bit mode
-*/
+ */
 .align  8
 .global _boot_gdt_start
 _boot_gdt_start:
@@ -113,8 +113,6 @@ _boot_gdt_start:
         .quad   0x0000000000000000      // 0x08 unused
         .quad   0x00a09b000000ffff      // 0x10 kernel code
         .quad   0x00a093000000ffff      // 0x18 kernel data
-        .quad   0x00a09b000000ffff      // 0x20 user code in ring 3
-        .quad   0x00a093000000ffff      // 0x28 user data in ring 3
 _boot_gdt_end:
         .word   0                       // padding to align ...
 _boot_gdt:

--- a/kernel/boot/kernel-amd64-knc/boot/start.S
+++ b/kernel/boot/kernel-amd64-knc/boot/start.S
@@ -57,14 +57,14 @@ _host_debug_info:
  * If bit 16 in the ‘flags’ word is set, then the fields at offsets 12-28 in the Multiboot header are valid, and the boot loader should use them instead of the fields in the actual executable header to calculate where to load the OS image. This information does not need to be provided if the kernel image is in elf format.
  */
 #define MULTIBOOT_HEADER_FLAGS          0x00000000
-        
+
 .align  4
 /** multiboot header: just magic, flags and checksum without the optional fields */
 _mboot_header:
         .long MULTIBOOT_HEADER_MAGIC
         .long MULTIBOOT_HEADER_FLAGS
         .long -(MULTIBOOT_HEADER_MAGIC+MULTIBOOT_HEADER_FLAGS)
-        
+
 /** Global Descriptor Table (GDT) during boot wiht five segments.
  * see 3.4.5.1 Code- and Data-Segment Descriptor Types in Intel 253668-048US.
  * granularity 0xa0 = 10100000b => limit granularity 4kb, operand size unset, 64bit mode
@@ -112,7 +112,7 @@ _start_bsp:
         // activate the initial page table
         mov     $0xc0000080, %rcx       // select the EFER MSR
         rdmsr                           // read EFER
-        or      $0x101, %rax            // set LME (bit8) and enable SYSCALL (bit0), XXX enable noexecute (bit11)
+        or      $0x901, %rax            // IA-32e mode enable (bit8), SYSCALL (bit0), noexecute (bit11)
         wrmsr                           // write EFER
         mov     %cr4, %rdx
         or      $0x20, %rdx             // enable PAE mode (bit5), XXX enable SMAP,SMEP,PCE later?
@@ -155,7 +155,7 @@ _setup_ap:
         // init paging and load stage 1 page table
         mov $0xc0000080, %ecx // select the EFER MSR
         rdmsr
-        or $0x101, %eax // set LME (bit8) and enable SYSCALL (bit0), XXX enable noexecute (bit11)
+        or $0x901, %eax // IA-32e mode enable (bit8), SYSCALL (bit0), noexecute (bit11)
         wrmsr
         mov %cr4, %edx
         or $0x20, %edx // enable PAE mode (bit5), XXX enable SMAP,SMEP,PCE later?

--- a/kernel/boot/kernel-amd64-knc/boot/start.S
+++ b/kernel/boot/kernel-amd64-knc/boot/start.S
@@ -120,7 +120,7 @@ _start_bsp:
         mov     $(BOOT_PML4-VIRT_ADDR), %rdx             // pointer to the Page Directory
         mov     %rdx, %cr3
         mov     %cr0, %rdx
-        or     $0x80010001, %edx        // enable PE (bit0), WP (bit16), PG (bit31)
+        or     $0x80050033, %edx        // enable PE(bit0), MP(bit1), ET(bit4), NE(bit5), AM(bit18), WP(bit16), PG(bit31)
         mov     %rdx, %cr0              // switch to protected mode, with paging enabled and write protect
         // load our own segment descriptor table
         lgdt    _boot_gdt
@@ -163,7 +163,7 @@ _setup_ap:
         mov $(BOOT_PML4-VIRT_ADDR), %edx
         mov %edx, %cr3 // load phys pointer of the PML4 table
         mov %cr0, %edx
-        or $0x80010001, %edx // enable PE (bit0), WP (bit16), PG (bit31)
+        or $0x80050033, %edx // enable PE(bit0), MP(bit1), ET(bit4), NE(bit5), AM(bit18), WP(bit16), PG(bit31)
         mov %edx, %cr0
 
         // load gdt via relative address

--- a/kernel/boot/kernel-amd64-knc/boot/start.S
+++ b/kernel/boot/kernel-amd64-knc/boot/start.S
@@ -183,6 +183,46 @@ _setup_ap_end:
 .code64
 .align  8
 _start_ap64_low:
+        movq $0, %rdi
+        jmp _start_ap64
+
+.code16
+.align  16
+.global _setup_ap_cc6
+_setup_ap_cc6:
+        cli
+        // init paging and load stage 1 page table
+        mov $0xc0000080, %ecx // select the EFER MSR
+        rdmsr
+        or $0x901, %eax // IA-32e mode enable (bit8), SYSCALL (bit0), noexecute (bit11)
+        wrmsr
+        mov %cr4, %edx
+        or $0x20, %edx // enable PAE mode (bit5), XXX enable SMAP,SMEP,PCE later?
+        mov %edx, %cr4
+        mov $(BOOT_PML4-VIRT_ADDR), %edx
+        mov %edx, %cr3 // load phys pointer of the PML4 table
+        mov %cr0, %edx
+        or $0x80050033, %edx // enable PE(bit0), MP(bit1), ET(bit4), NE(bit5), AM(bit18), WP(bit16), PG(bit31)
+        mov %edx, %cr0
+
+        // load gdt via relative address
+        lgdtl %cs:__gdt_desc_cc6 - _setup_ap_cc6
+
+        // jump to next stage
+        // this switches from 16 to 64 bit mode and actives the paging
+        ljmpl $0x10, $_start_ap64_low_cc6
+
+        // need a local gdt descriptor, because lgdtl can only handle 16bit relative addresses
+__gdt_desc_cc6:
+        .word _boot_gdt_end - _boot_gdt_start - 1
+        .quad _boot_gdt_start
+.global _setup_ap_end_cc6
+_setup_ap_end_cc6:
+
+.code64
+.align  8
+_start_ap64_low_cc6:
+        movq $1, %rdi
         jmp _start_ap64
 
 .section .text
@@ -207,9 +247,9 @@ _start_ap64:
         shr $24, %rbx
         and $0xFF, %rbx
 
-        // load stack address and hwt address as first argument for main_ap
-        movq ap_startup_stacks(,%rbx,8), %rsp
-        movq %rbx, %rdi
+        movq ap_startup_stacks(,%rbx,8), %rsp // load stack address
+        movq %rdi, %rsi // reason as 2nd argument (rsi)
+        movq %rbx, %rdi // hwt address as first argument (rdi) for main_ap
 
         // go to the stage 3 boot code, and never come back
         xor %rbp, %rbp

--- a/kernel/boot/kernel-amd64-knc/boot/start.S
+++ b/kernel/boot/kernel-amd64-knc/boot/start.S
@@ -33,6 +33,37 @@
 
 .section .init, "awx"  // the following code and data is in the low memory init section
 
+// EFER bit 0: SYSCALL instruction enable
+// EFER bit 8: IA-32e mode enable
+// EFER bit 11: enable noexecute bit in page tables
+#define EFER_MASK    0xFFFFFFFF
+#define EFER_ENABLE  0x00000901
+#define EFER_MSR     0xc0000080
+
+// CR0 bit 0: PE protected mode enable
+// CR0 bit 1: MP monitor co-processor
+// CR0 bit 4: ET 80387 coprocessor
+// CR0 bit 5: NE enable x87 floating point error reporting
+// CR0 bit 16: WP enable write protection
+// CR0 bit 18: AM enable alignment checks (needs EFLAGS for ring3)
+// CR0 bit 31: PG enable paging
+#define CR0_MASK     0xFFFFFFFF
+#define CR0_ENABLE   0x80050033
+
+// CR4 bit 5: enable PAE mode
+// -CR4 bit 8: PCE Performance-Monitoring Counter enable for user mode
+// -CR4 bit 6: MCE enable Machine Check Exception
+// -CR4 bit 9: OSFXSR Operating system support for FXSAVE and FXRSTOR instructions
+// -CR4 bit 10: OSXMMEXCPT Operating System Support for Unmasked SIMD Floating-Point Exceptions
+// -CR4 bit 13: VMXE enable Virtual Machine Extensions
+// -CR4 bit 16: FSGSBASE Enables the instructions
+// -CR4 bit 17: PCIDE enable TLB PCIDs for faster address space switching
+// -CR4 bit 18: OSXSAVE XSAVE and Processor Extended States Enable
+// -CR4 bit 20: SMEP Supervisor Mode Execution Protection Enable
+// -CR4 bit 21: SMAP Supervisor Mode Access Prevention Enable
+#define CR4_MASK     0xFFFFFFFF
+#define CR4_ENABLE   0x00000020
+        
 /** Contains physical address of a struct
  * with pointers to communication channels.
  * It will be read by the host tools.
@@ -110,17 +141,20 @@ _start_bsp:
 
         movq $__LINE__, _host_debug_info
         // activate the initial page table
-        mov     $0xc0000080, %rcx       // select the EFER MSR
+        mov     $(EFER_MSR), %rcx       // select the EFER MSR
         rdmsr                           // read EFER
-        or      $0x901, %rax            // IA-32e mode enable (bit8), SYSCALL (bit0), noexecute (bit11)
+        and     $(EFER_MASK), %eax
+        or      $(EFER_ENABLE), %eax
         wrmsr                           // write EFER
         mov     %cr4, %rdx
-        or      $0x20, %rdx             // enable PAE mode (bit5), XXX enable SMAP,SMEP,PCE later?
+        and     $(CR4_MASK), %edx
+        or      $(CR4_ENABLE), %edx
         mov     %rdx, %cr4
         mov     $(BOOT_PML4-VIRT_ADDR), %rdx             // pointer to the Page Directory
         mov     %rdx, %cr3
         mov     %cr0, %rdx
-        or     $0x80050033, %edx        // enable PE(bit0), MP(bit1), ET(bit4), NE(bit5), AM(bit18), WP(bit16), PG(bit31)
+        and     $(CR0_MASK), %edx
+        or      $(CR0_ENABLE), %edx
         mov     %rdx, %cr0              // switch to protected mode, with paging enabled and write protect
         // load our own segment descriptor table
         lgdt    _boot_gdt
@@ -153,17 +187,20 @@ _start_bsp64:
 _setup_ap:
         cli
         // init paging and load stage 1 page table
-        mov $0xc0000080, %ecx // select the EFER MSR
+        mov $(EFER_MSR), %ecx // select the EFER MSR
         rdmsr
-        or $0x901, %eax // IA-32e mode enable (bit8), SYSCALL (bit0), noexecute (bit11)
+        and     $(EFER_MASK), %eax
+        or      $(EFER_ENABLE), %eax
         wrmsr
         mov %cr4, %edx
-        or $0x20, %edx // enable PAE mode (bit5), XXX enable SMAP,SMEP,PCE later?
+        and     $(CR4_MASK), %edx
+        or      $(CR4_ENABLE), %edx
         mov %edx, %cr4
         mov $(BOOT_PML4-VIRT_ADDR), %edx
         mov %edx, %cr3 // load phys pointer of the PML4 table
         mov %cr0, %edx
-        or $0x80050033, %edx // enable PE(bit0), MP(bit1), ET(bit4), NE(bit5), AM(bit18), WP(bit16), PG(bit31)
+        and     $(CR0_MASK), %edx
+        or      $(CR0_ENABLE), %edx
         mov %edx, %cr0
 
         // load gdt via relative address
@@ -192,17 +229,20 @@ _start_ap64_low:
 _setup_ap_cc6:
         cli
         // init paging and load stage 1 page table
-        mov $0xc0000080, %ecx // select the EFER MSR
+        mov $(EFER_MSR), %ecx // select the EFER MSR
         rdmsr
-        or $0x901, %eax // IA-32e mode enable (bit8), SYSCALL (bit0), noexecute (bit11)
+        and     $(EFER_MASK), %eax
+        or      $(EFER_ENABLE), %eax
         wrmsr
         mov %cr4, %edx
-        or $0x20, %edx // enable PAE mode (bit5), XXX enable SMAP,SMEP,PCE later?
+        and     $(CR4_MASK), %edx
+        or      $(CR4_ENABLE), %edx
         mov %edx, %cr4
         mov $(BOOT_PML4-VIRT_ADDR), %edx
         mov %edx, %cr3 // load phys pointer of the PML4 table
         mov %cr0, %edx
-        or $0x80050033, %edx // enable PE(bit0), MP(bit1), ET(bit4), NE(bit5), AM(bit18), WP(bit16), PG(bit31)
+        and     $(CR0_MASK), %edx
+        or      $(CR0_ENABLE), %edx
         mov %edx, %cr0
 
         // load gdt via relative address

--- a/kernel/boot/kernel-amd64-pc/boot/start.S
+++ b/kernel/boot/kernel-amd64-pc/boot/start.S
@@ -100,7 +100,7 @@ _start_bsp:
         // activate the initial page table
         mov     $0xc0000080, %ecx       // select the EFER MSR
         rdmsr                           // read EFER
-        or      $0x101, %eax            // set LME (bit8) and enable SYSCALL (bit0), XXX enable noexecute (bit11)
+        or      $0x901, %rax            // IA-32e mode enable (bit8), SYSCALL (bit0), noexecute (bit11)
         wrmsr                           // write EFER
         mov     %cr4, %edx
         or      $0x20, %edx             // enable PAE mode (bit5), XXX enable SMAP,SMEP,PCE later?
@@ -108,7 +108,7 @@ _start_bsp:
         mov     $(BOOT_PML4-VIRT_ADDR), %edx             // pointer to the Page Directory
         mov     %edx, %cr3
         mov     %cr0, %edx
-        or     $0x80010001, %edx        // enable PE (bit0), WP (bit16), PG (bit31)
+        or     $0x80050033, %edx        // enable PE(bit0), MP(bit1), ET(bit4), NE(bit5), AM(bit18), WP(bit16), PG(bit31)
         mov     %edx, %cr0              // switch to protected mode, with paging enabled and write protect
 
         // load our own segment descriptor table
@@ -141,7 +141,7 @@ _setup_ap:
         // init paging and load stage 1 page table
         mov $0xc0000080, %ecx // select the EFER MSR
         rdmsr
-        or $0x101, %eax // set LME (bit8) and enable SYSCALL (bit0), XXX enable noexecute (bit11)
+        or $0x901, %eax // IA-32e mode enable (bit8), SYSCALL (bit0), noexecute (bit11)
         wrmsr
         mov %cr4, %edx
         or $0x20, %edx // enable PAE mode (bit5), XXX enable SMAP,SMEP,PCE later?
@@ -149,7 +149,7 @@ _setup_ap:
         mov $BOOT_PML4-VIRT_ADDR, %edx
         mov %edx, %cr3 // load phys pointer of the PML4 table
         mov %cr0, %edx
-        or $0x80010001, %edx // enable PE (bit0), WP (bit16), PG (bit31)
+        or $0x80050033, %edx // enable PE(bit0), MP(bit1), ET(bit4), NE(bit5), AM(bit18), WP(bit16), PG(bit31)
         mov %edx, %cr0
 
         // load gdt via relative address

--- a/kernel/boot/kernel-amd64-pc/boot/start.S
+++ b/kernel/boot/kernel-amd64-pc/boot/start.S
@@ -84,7 +84,7 @@ _mboot_header:
         .long MULTIBOOT_HEADER_FLAGS
         .long -(MULTIBOOT_HEADER_MAGIC+MULTIBOOT_HEADER_FLAGS)
 
-/** Global Descriptor Table (GDT) during boot wiht five segments.
+/** Global Descriptor Table (GDT) during boot.
  * see 3.4.5.1 Code- and Data-Segment Descriptor Types in Intel 253668-048US.
  * granularity 0xa0 = 10100000b => limit granularity 4kb, operand size unset, 64bit mode
  * access 0x9b = 10011011b => present, ring0, code/data, Execute/Read accessed
@@ -93,7 +93,7 @@ _mboot_header:
  *  1011 execute/read accessed
  *  access 0xfb = 11111011 => present, ring3, code/data, Execute/Read accessed
  *  limit can be 0 because it is not used in 64bit mode
-*/
+ */
 .align  8
 .global _boot_gdt_start
 _boot_gdt_start:

--- a/kernel/boot/kernel-amd64-pc/boot/start.S
+++ b/kernel/boot/kernel-amd64-pc/boot/start.S
@@ -100,7 +100,7 @@ _start_bsp:
         // activate the initial page table
         mov     $0xc0000080, %ecx       // select the EFER MSR
         rdmsr                           // read EFER
-        or      $0x901, %rax            // IA-32e mode enable (bit8), SYSCALL (bit0), noexecute (bit11)
+        or      $0x901, %eax            // IA-32e mode enable (bit8), SYSCALL (bit0), noexecute (bit11)
         wrmsr                           // write EFER
         mov     %cr4, %edx
         or      $0x20, %edx             // enable PAE mode (bit5), XXX enable SMAP,SMEP,PCE later?
@@ -169,6 +169,7 @@ _setup_ap_end:
 .code64
 .align  8
 _start_ap64_low:
+        movq $0, %rdi
         jmp _start_ap64
 
 .section .text
@@ -193,9 +194,10 @@ _start_ap64:
         shr $24, %rbx
         and $0xFF, %rbx
 
-        // load stack address and hwt address as first argument for main_ap
+        // load stack address
         movq ap_startup_stacks(,%rbx,8), %rsp
-        movq %rbx, %rdi
+        movq %rdi, %rsi // reason as 2nd argument (rsi)
+        movq %rbx, %rdi // hwt address as first argument (rdi) for main_ap
 
         // go to the stage 3 boot code, and never come back
         xor %rbp, %rbp

--- a/kernel/boot/kernel-amd64-pc/boot/start.S
+++ b/kernel/boot/kernel-amd64-pc/boot/start.S
@@ -33,6 +33,37 @@
 
 .section .init, "awx"  // the following code and data is in the low memory init section
 
+// EFER bit 0: SYSCALL instruction enable
+// EFER bit 8: IA-32e mode enable
+// EFER bit 11: enable noexecute bit in page tables
+#define EFER_MASK    0xFFFFFFFF
+#define EFER_ENABLE  0x00000901
+#define EFER_MSR     0xc0000080
+
+// CR0 bit 0: PE protected mode enable
+// CR0 bit 1: MP monitor co-processor
+// CR0 bit 4: ET 80387 coprocessor
+// CR0 bit 5: NE enable x87 floating point error reporting
+// CR0 bit 16: WP enable write protection
+// CR0 bit 18: AM enable alignment checks (needs EFLAGS for ring3)
+// CR0 bit 31: PG enable paging
+#define CR0_MASK     0xFFFFFFFF
+#define CR0_ENABLE   0x80050033
+
+// CR4 bit 5: enable PAE mode
+// -CR4 bit 8: PCE Performance-Monitoring Counter enable for user mode
+// -CR4 bit 6: MCE enable Machine Check Exception
+// -CR4 bit 9: OSFXSR Operating system support for FXSAVE and FXRSTOR instructions
+// -CR4 bit 10: OSXMMEXCPT Operating System Support for Unmasked SIMD Floating-Point Exceptions
+// -CR4 bit 13: VMXE enable Virtual Machine Extensions
+// -CR4 bit 16: FSGSBASE Enables the instructions
+// -CR4 bit 17: PCIDE enable TLB PCIDs for faster address space switching
+// -CR4 bit 18: OSXSAVE XSAVE and Processor Extended States Enable
+// -CR4 bit 20: SMEP Supervisor Mode Execution Protection Enable
+// -CR4 bit 21: SMAP Supervisor Mode Access Prevention Enable
+#define CR4_MASK     0xFFFFFFFF
+#define CR4_ENABLE   0x00000020
+
 /** magic number for the Multiboot header. */
 #define MULTIBOOT_HEADER_MAGIC          0x1BADB002
 
@@ -98,18 +129,21 @@ _start_bsp:
         mov %ebx, _mboot_table
 
         // activate the initial page table
-        mov     $0xc0000080, %ecx       // select the EFER MSR
+        mov     $(EFER_MSR), %ecx       // select the EFER MSR
         rdmsr                           // read EFER
-        or      $0x901, %eax            // IA-32e mode enable (bit8), SYSCALL (bit0), noexecute (bit11)
+        and     $(EFER_MASK), %eax
+        or      $(EFER_ENABLE), %eax
         wrmsr                           // write EFER
         mov     %cr4, %edx
-        or      $0x20, %edx             // enable PAE mode (bit5), XXX enable SMAP,SMEP,PCE later?
+        and     $(CR4_MASK), %edx
+        or      $(CR4_ENABLE), %edx
         mov     %edx, %cr4
-        mov     $(BOOT_PML4-VIRT_ADDR), %edx             // pointer to the Page Directory
+        mov     $(BOOT_PML4-VIRT_ADDR), %edx // pointer to the Page Directory
         mov     %edx, %cr3
         mov     %cr0, %edx
-        or     $0x80050033, %edx        // enable PE(bit0), MP(bit1), ET(bit4), NE(bit5), AM(bit18), WP(bit16), PG(bit31)
-        mov     %edx, %cr0              // switch to protected mode, with paging enabled and write protect
+        and     $(CR0_MASK), %edx
+        or      $(CR0_ENABLE), %edx
+        mov     %edx, %cr0  // switch to protected mode, with paging enabled and write protect
 
         // load our own segment descriptor table
         lgdt    _boot_gdt
@@ -139,17 +173,20 @@ _start_bsp64:
 _setup_ap:
         cli
         // init paging and load stage 1 page table
-        mov $0xc0000080, %ecx // select the EFER MSR
+        mov $(EFER_MSR), %ecx // select the EFER MSR
         rdmsr
-        or $0x901, %eax // IA-32e mode enable (bit8), SYSCALL (bit0), noexecute (bit11)
+        and     $(EFER_MASK), %eax
+        or      $(EFER_ENABLE), %eax
         wrmsr
         mov %cr4, %edx
-        or $0x20, %edx // enable PAE mode (bit5), XXX enable SMAP,SMEP,PCE later?
+        and     $(CR4_MASK), %edx
+        or      $(CR4_ENABLE), %edx
         mov %edx, %cr4
         mov $BOOT_PML4-VIRT_ADDR, %edx
         mov %edx, %cr3 // load phys pointer of the PML4 table
         mov %cr0, %edx
-        or $0x80050033, %edx // enable PE(bit0), MP(bit1), ET(bit4), NE(bit5), AM(bit18), WP(bit16), PG(bit31)
+        and     $(CR0_MASK), %edx
+        or      $(CR0_ENABLE), %edx
         mov %edx, %cr0
 
         // load gdt via relative address

--- a/kernel/boot/kernel-main/boot/kernel.cc
+++ b/kernel/boot/kernel-main/boot/kernel.cc
@@ -61,7 +61,7 @@ extern char CLM_END;
 uint64_t mythos::tscdelay_MHz=2000;
 
 NORETURN void entry_bsp() SYMBOL("entry_bsp");
-NORETURN void entry_ap(size_t id) SYMBOL("entry_ap");
+NORETURN void entry_ap(size_t apicID, size_t reason) SYMBOL("entry_ap");
 
 /** entry point for the bootstrap processor (BSP, a hardware thread) when booting the processor.
  *
@@ -73,6 +73,7 @@ void entry_bsp()
 {
   mythos::boot::initKernelSpace();
   mythos::boot::mapLapic(mythos::x86::getApicBase()); // make LAPIC accessible
+  /// @todo needed? mythos::boot::loadKernelSpace();
   mythos::GdtAmd64 tempGDT;
   tempGDT.init();
   tempGDT.load();
@@ -112,11 +113,11 @@ void runUser() {
  * that case, some initializations have to be skipped. Just the
  * hardware thread is configured to the default environment.
  */
-void entry_ap(size_t apicID)
+void entry_ap(size_t apicID, size_t reason)
 {
   //asm volatile("xchg %bx,%bx");
   mythos::boot::apboot_thread(apicID);
-  MLOG_DETAIL(mlog::boot, "started hardware thread");
+  MLOG_DETAIL(mlog::boot, "started hardware thread", DVAR(reason));
   runUser();
 }
 

--- a/kernel/boot/kernel-main/mcconf.module
+++ b/kernel/boot/kernel-main/mcconf.module
@@ -3,7 +3,7 @@
     incfiles = [ "boot/boot.ld" ]
     kernelfiles = [ "boot/kernel.cc" ]
     requires = [ "tag/mode/kernel" ]
-    provides = [ "symbol/entry_bsp", "symbol/entry_ap",
+    provides = [ "symbol/entry_bsp", "symbol/entry_ap", "symbol/sleeping_failed",
     "symbol/syscall_entry_cxx", "symbol/irq_entry_user", "symbol/irq_entry_kernel" ]
 
     makefile_head = '''

--- a/kernel/boot/kernelspace-amd64/boot/init-kernelspace-common.cc
+++ b/kernel/boot/kernelspace-amd64/boot/init-kernelspace-common.cc
@@ -51,16 +51,17 @@ void initKernelSpaceCommon()
     pml2_tables[i] &= ~WRITE;
   }
   // rw but no execute access on kernel data in image from KERN_ROEND to KERN_END
-  // TODO: set EXECUTEDISABLE
+  /// @todo set NOEXECUTE
   // remove access (read and write) from remaining space behind KERN_END in the image
   // first 8 entries are already invalid (see pagetables.cc.m4)
   for (auto i = 8+reinterpret_cast<uintptr_t>(&KERN_END)/PML2_PAGESIZE; i<1024; i++) {
     image_pml2[i] &= ~PRESENT;
   }
+}
 
-  // switch to final address space without lower half, reload TLB
+void loadKernelSpace()
+{
   asm volatile("mov %0,%%cr3": : "r" (table_to_phys_addr(pml4_table,1)));
-  // can no longer write directly to the init and initdata section from here on
 }
 
 void mapLapic(uintptr_t phys)

--- a/kernel/boot/kernelspace-amd64/boot/init-kernelspace-common.hh
+++ b/kernel/boot/kernelspace-amd64/boot/init-kernelspace-common.hh
@@ -32,6 +32,12 @@ namespace mythos {
   namespace boot {
 
     void initKernelSpaceCommon();
+
+    /** switch to final address space without lower half, reload TLB.
+     * can no longer write directly to the init and initdata section from here on.
+     */
+    void loadKernelSpace();
+
     void mapLapic(uintptr_t phys);
 
     /** maps a kernel stack to the given physical address and returns the logical address */

--- a/kernel/build/gcc-kernel-knc/util/compiler.hh
+++ b/kernel/build/gcc-kernel-knc/util/compiler.hh
@@ -41,6 +41,9 @@
 #define PURE                __attribute__((pure))
 #define SYMBOL(x)		asm(x)
 
+#define LIKELY(x)       __builtin_expect((x),1)
+#define UNLIKELY(x)     __builtin_expect((x),0)
+
 #define CONSTEXPR constexpr
 #define NOEXCEPT noexcept
 #define WARN_UNUSED __attribute__((warn_unused_result))

--- a/kernel/build/gcc-kernel-pc/util/compiler.hh
+++ b/kernel/build/gcc-kernel-pc/util/compiler.hh
@@ -41,6 +41,9 @@
 #define PURE                __attribute__((pure))
 #define SYMBOL(x)		asm(x)
 
+#define LIKELY(x)       __builtin_expect((x),1)
+#define UNLIKELY(x)     __builtin_expect((x),0)
+
 #define CONSTEXPR constexpr
 #define NOEXCEPT noexcept
 #define WARN_UNUSED __attribute__((warn_unused_result))

--- a/kernel/cpu/idle-hlt/cpu/idle.hh
+++ b/kernel/cpu/idle-hlt/cpu/idle.hh
@@ -34,8 +34,8 @@ namespace mythos {
     /** called once on bootup by the BSP. Initialises the trampoline and core states. */
     void init_global() {}
 
-    /** called once on bootup on each AP. Initialises the core-local pointers */
-    void init_thread(cpu::ThreadID /*threadID*/) {}
+    /** called once on bootup on each AP to initialise the processor, if needed. */
+    void init_thread() {}
 
     /** dependency: has to be implemented by kernel */
     NORETURN void sleeping_failed() SYMBOL("sleeping_failed");

--- a/kernel/cpu/idle-hlt/cpu/idle.hh
+++ b/kernel/cpu/idle-hlt/cpu/idle.hh
@@ -1,0 +1,60 @@
+/* -*- mode:C++; -*- */
+/* MIT License -- MyThOS: The Many-Threads Operating System
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright 2016 Randolf Rotta, Robert Kuban, Maik Krüger, and contributors, BTU Cottbus-Senftenberg
+ */
+#pragma once
+
+#include "util/compiler.hh"
+
+namespace mythos {
+  namespace idle {
+
+    /** called once on bootup by the BSP. Initialises the trampoline and core states. */
+    void init_global() {}
+
+    /** called once on bootup on each AP. Initialises the core-local pointers */
+    void init_thread(size_t /*apicID*/) {}
+
+    /** dependency: has to be implemented by kernel */
+    NORETURN void sleeping_failed() SYMBOL("sleeping_failed");
+
+    /** The kernel has nothing to do, thus go sleeping.
+     * Resets the kernel stack.
+     */
+    NORETURN void sleep() SYMBOL("idle_sleep");
+
+    /** sleep management event: awakened by booting or from deep sleep. */
+    void wokeup(size_t /*apicID*/, size_t /*reason*/) {}
+
+    /** sleep management event: awakened by interrupt, possibly from light sleep */
+    void wokeupFromInterrupt() {}
+
+    /** sleep management event: entered kernel from syscall */
+    void enteredFromSyscall() {}
+
+    /** sleep management event: entered kernel from interrupting the user mode */
+    void enteredFromInterrupt() {}
+
+  } // namespace idle
+} // namespace mythos

--- a/kernel/cpu/idle-hlt/cpu/idle.hh
+++ b/kernel/cpu/idle-hlt/cpu/idle.hh
@@ -40,10 +40,15 @@ namespace mythos {
     /** dependency: has to be implemented by kernel */
     NORETURN void sleeping_failed() SYMBOL("sleeping_failed");
 
+    /** low level assembler routine that halts the hardware thread. */
+    NORETURN void cpu_idle_halt() SYMBOL("cpu_idle_halt");
+
     /** The kernel has nothing to do, thus go sleeping.
-     * Resets the kernel stack.
+     *
+     * High level idle governers may replace this function. (somehow)
+     * resets the kernel stack.
      */
-    NORETURN void sleep() SYMBOL("idle_sleep");
+    NORETURN void sleep() { cpu_idle_halt(); }
 
     /** sleep management event: awakened by booting or from deep sleep. */
     void wokeup(size_t /*apicID*/, size_t /*reason*/) {}

--- a/kernel/cpu/idle-hlt/cpu/idle_lowlevel.S
+++ b/kernel/cpu/idle-hlt/cpu/idle_lowlevel.S
@@ -32,7 +32,7 @@
 idle_sleep:
         mov %gs:kernel_stack, %rsp      // start on a clean stack to avoid filling it up
         pushq   $0 // fake return address
-        pushq   $0 // fake rbp
+        pushq   $0 // fake rbp, end for stack unwinding
         sti
         hlt
         cli

--- a/kernel/cpu/idle-hlt/cpu/idle_lowlevel.S
+++ b/kernel/cpu/idle-hlt/cpu/idle_lowlevel.S
@@ -1,0 +1,41 @@
+/* -*- mode:asm; indent-tabs-mode:nil -*- */
+/* MIT License -- MyThOS: The Many-Threads Operating System
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright 2016 Randolf Rotta, Robert Kuban, Maik Krüger, and contributors, BTU Cottbus-Senftenberg
+ */
+
+.extern kernel_stack
+.extern sleeping_failed
+
+.global idle_sleep
+.type idle_sleep, @function
+idle_sleep:
+        mov %gs:kernel_stack, %rsp      // start on a clean stack to avoid filling it up
+        pushq   $0 // fake return address
+        pushq   $0 // fake rbp
+        sti
+        hlt
+        cli
+        xor %rbp, %rbp
+        pushq   $0 // fake return address
+        jmp sleeping_failed

--- a/kernel/cpu/idle-hlt/cpu/idle_lowlevel.S
+++ b/kernel/cpu/idle-hlt/cpu/idle_lowlevel.S
@@ -27,9 +27,9 @@
 .extern kernel_stack
 .extern sleeping_failed
 
-.global idle_sleep
-.type idle_sleep, @function
-idle_sleep:
+.global cpu_idle_halt
+.type cpu_idle_halt, @function
+cpu_idle_halt:
         mov %gs:kernel_stack, %rsp      // start on a clean stack to avoid filling it up
         pushq   $0 // fake return address
         pushq   $0 // fake rbp, end for stack unwinding

--- a/kernel/cpu/idle-hlt/mcconf.module
+++ b/kernel/cpu/idle-hlt/mcconf.module
@@ -1,0 +1,5 @@
+# -*- mode:toml; -*-
+[module.kernel-idle-hlt]
+    incfiles = [ "cpu/idle.hh" ]
+    kernelfiles = [ "cpu/idle_lowlevel.S" ]
+    requires = [ "symbol/sleeping_failed" ]

--- a/kernel/cpu/idle-knc/cpu/idle.cc
+++ b/kernel/cpu/idle-knc/cpu/idle.cc
@@ -58,7 +58,7 @@ namespace mythos {
         MLOG_ERROR(mlog::boot, "idle: C6_SCRATCH", DVAR(i), DVARhex(cc6[i]));
     }
 
-    NORETURN void go_sleeping() SYMBOL("idle_sleep");
+    NORETURN void cpu_idle_halt() SYMBOL("cpu_idle_halt");
 
     void sleep()
     {
@@ -77,7 +77,7 @@ namespace mythos {
       MLOG_ERROR(mlog::boot, "idle: cores halted", DVARhex(*chlt));
 
       coreStates[apicID/4].lock = false;
-      go_sleeping();
+      cpu_idle_halt();
     }
 
     void wokeup(size_t /*apicID*/, size_t reason)
@@ -85,7 +85,7 @@ namespace mythos {
       MLOG_ERROR(mlog::boot, "idle:", DVARhex(x86::getMSR(MSR_CC6_STATUS)));
       if (reason == 1) {
 	MLOG_ERROR(mlog::boot, "idle: woke up from CC6");
-	go_sleeping(); // woke up from CC6 => just sleep again
+	cpu_idle_halt(); // woke up from CC6 => just sleep again
       }
     }
 

--- a/kernel/cpu/idle-knc/cpu/idle.cc
+++ b/kernel/cpu/idle-knc/cpu/idle.cc
@@ -1,0 +1,100 @@
+/* -*- mode:C++; -*- */
+/* MIT License -- MyThOS: The Many-Threads Operating System
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright 2016 Randolf Rotta, Robert Kuban, Maik Krüger, and contributors, BTU Cottbus-Senftenberg
+ */
+
+#include "cpu/idle.hh"
+#include "util/mstring.hh" // for memcpy
+#include "boot/memory-layout.h" // for KNC MMIO
+#include "cpu/ctrlregs.hh"
+
+#define SBOX_C6_SCRATCH0 0x0000C000
+#define MSR_CC6_STATUS 0x342
+
+extern char _setup_ap_cc6;
+extern char _setup_ap_end_cc6;
+
+namespace mythos {
+  namespace idle {
+
+    CoreState coreStates[61];
+    //CoreLocal<CoreState*> coreState KERNEL_CLM;
+
+    void init_global()
+    {
+      // copy CC6 trampoline to the right place
+      memcpy(PhysPtr<char>(0x60000).log(),
+	     physPtr(&_setup_ap_cc6).log(),
+	     size_t(&_setup_ap_end_cc6 - &_setup_ap_cc6));
+      asm volatile("wbinvd");
+
+      // copy PC6 trampoline to the right place
+      // memcpy(PhysPtr<char>(0x70000).log(),
+      //        physPtr(&_setup_ap_pc6).log(),
+      //        size_t(&_setup_ap_end_pc6 - &_setup_ap_pc6));
+      // asm volatile("wbinvd");
+
+      // turn on caches during re-entry from CC6 sleep
+      auto cc6 = reinterpret_cast<uint32_t volatile*>(MMIO_ADDR+SBOX_BASE+SBOX_C6_SCRATCH0);
+      *cc6 |= 0x8000; // C1-CC6 MAS (bit 15)
+    }
+
+    void init_thread(size_t /*apicID*/)
+    {
+      //coreState.set(&coreStates[apicID/4]);
+    }
+
+    NORETURN void go_sleeping() SYMBOL("idle_sleep");
+
+    void sleep()
+    {
+      size_t apicID = cpu::hwThreadID(); /// @todo should be getApicID()
+      auto prev = coreStates[apicID/4].cc6ready.fetch_or(uint8_t(1 << (apicID%4)));
+      if (prev | (1 << (apicID%4))) { // enable cc6
+        /// @todo is this really needed if we always go into cc6?
+        auto val = x86::getMSR(MSR_CC6_STATUS);
+        val |= 0x1f;
+        x86::setMSR(MSR_CC6_STATUS,val);
+      }
+      go_sleeping();
+    }
+
+    void wokeup(size_t /*apicID*/, size_t reason)
+    {
+      if (reason == 1) go_sleeping(); // woke up from CC6 => just sleep again
+    }
+
+    void wokeupFromInterrupt()
+    {
+      size_t apicID = cpu::hwThreadID(); /// @todo should be getApicID()
+      auto prev = coreStates[apicID/4].cc6ready.fetch_and(uint8_t(~(1u << (apicID%4))));
+      if (prev == 0xf) { // disable cc6
+        auto val = x86::getMSR(MSR_CC6_STATUS);
+        val &= ~0x1f;
+        x86::setMSR(MSR_CC6_STATUS,val);
+      }
+    }
+
+  } // namespace idle
+} // namespace mythos

--- a/kernel/cpu/idle-knc/cpu/idle.hh
+++ b/kernel/cpu/idle-knc/cpu/idle.hh
@@ -37,6 +37,7 @@ namespace mythos {
     {
     public:
       std::atomic<uint8_t> cc6ready = {0}; // one bit per hardware thread
+      std::atomic<bool> lock = {false};
     };
 
     /** called once on bootup by the BSP. Initialises the trampoline and core states. */

--- a/kernel/cpu/idle-knc/cpu/idle.hh
+++ b/kernel/cpu/idle-knc/cpu/idle.hh
@@ -1,0 +1,76 @@
+/* -*- mode:C++; -*- */
+/* MIT License -- MyThOS: The Many-Threads Operating System
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright 2016 Randolf Rotta, Robert Kuban, Maik Krüger, and contributors, BTU Cottbus-Senftenberg
+ */
+#pragma once
+
+#include "cpu/CoreLocal.hh"
+#include "util/compiler.hh"
+#include <atomic>
+#include <cstdint> // for uint32_t etc
+
+namespace mythos {
+  namespace idle {
+
+    class alignas(64) CoreState
+    {
+    public:
+      std::atomic<uint8_t> cc6ready = {0}; // one bit per hardware thread
+    };
+
+    /** called once on bootup by the BSP. Initialises the trampoline and core states. */
+    void init_global();
+
+    /** called once on bootup on each AP. Initialises the core-local pointers */
+    void init_thread(size_t apicID);
+
+    /** dependency: has to be implemented by kernel */
+    NORETURN void sleeping_failed() SYMBOL("sleeping_failed");
+
+    /** The kernel has nothing to do, thus go sleeping.
+     *
+     * High level idle governers may replace this function. (somehow)
+     * resets the kernel stack.
+     */
+    NORETURN void sleep();
+
+    /** sleep management event: awakened by booting or from deep sleep (CC6).
+     *
+     * When waking up from CC6, this call will not return. Instead the
+     * pending interrupt directly wakes up the next (internal) halt
+     * like waking up from CC1.
+     */
+    void wokeup(size_t apicID, size_t reason);
+
+    /** sleep management event: awakened by interrupt, possibly from light sleep (CC1) */
+    void wokeupFromInterrupt();
+
+    /** sleep management event: entered kernel from syscall */
+    void enteredFromSyscall() {}
+
+    /** sleep management event: entered kernel from interrupting the user mode */
+    void enteredFromInterrupt() {}
+
+  } // namespace idle
+} // namespace mythos

--- a/kernel/cpu/idle-knc/cpu/idle.hh
+++ b/kernel/cpu/idle-knc/cpu/idle.hh
@@ -43,8 +43,8 @@ namespace mythos {
     /** called once on bootup by the BSP. Initialises the trampoline and core states. */
     void init_global();
 
-    /** called once on bootup on each AP. Initialises the core-local pointers */
-    void init_thread(cpu::ThreadID /*threadID*/) {}
+    /** called once on bootup on each AP to initialise the processor, if needed. */
+    void init_thread() {}
 
     /** dependency: has to be implemented by kernel */
     NORETURN void sleeping_failed() SYMBOL("sleeping_failed");

--- a/kernel/cpu/idle-knc/cpu/idle_lowlevel.S
+++ b/kernel/cpu/idle-knc/cpu/idle_lowlevel.S
@@ -32,7 +32,7 @@
 idle_sleep:
         mov %gs:kernel_stack, %rsp      // start on a clean stack to avoid filling it up
         pushq   $0 // fake return address
-        pushq   $0 // fake rbp
+        pushq   $0 // fake rbp, end for stack unwinding
         sti
         hlt
         cli

--- a/kernel/cpu/idle-knc/cpu/idle_lowlevel.S
+++ b/kernel/cpu/idle-knc/cpu/idle_lowlevel.S
@@ -1,0 +1,41 @@
+/* -*- mode:asm; indent-tabs-mode:nil -*- */
+/* MIT License -- MyThOS: The Many-Threads Operating System
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright 2016 Randolf Rotta, Robert Kuban, Maik Krüger, and contributors, BTU Cottbus-Senftenberg
+ */
+
+.extern kernel_stack
+.extern sleeping_failed
+
+.global idle_sleep
+.type idle_sleep, @function
+idle_sleep:
+        mov %gs:kernel_stack, %rsp      // start on a clean stack to avoid filling it up
+        pushq   $0 // fake return address
+        pushq   $0 // fake rbp
+        sti
+        hlt
+        cli
+        xor %rbp, %rbp
+        pushq   $0 // fake return address
+        jmp sleeping_failed

--- a/kernel/cpu/idle-knc/cpu/idle_lowlevel.S
+++ b/kernel/cpu/idle-knc/cpu/idle_lowlevel.S
@@ -27,9 +27,9 @@
 .extern kernel_stack
 .extern sleeping_failed
 
-.global idle_sleep
-.type idle_sleep, @function
-idle_sleep:
+.global cpu_idle_halt
+.type cpu_idle_halt, @function
+cpu_idle_halt:
         mov %gs:kernel_stack, %rsp      // start on a clean stack to avoid filling it up
         pushq   $0 // fake return address
         pushq   $0 // fake rbp, end for stack unwinding

--- a/kernel/cpu/idle-knc/mcconf.module
+++ b/kernel/cpu/idle-knc/mcconf.module
@@ -1,0 +1,5 @@
+# -*- mode:toml; -*-
+[module.kernel-idle-knc]
+    incfiles = [ "cpu/idle.hh" ]
+    kernelfiles = [ "cpu/idle_lowlevel.S", "cpu/idle.cc" ]
+    requires = [ "symbol/sleeping_failed", "tag/platform/knc" ]

--- a/kernel/cpu/kernel-entry-amd64/cpu/irq_entry.S
+++ b/kernel/cpu/kernel-entry-amd64/cpu/irq_entry.S
@@ -137,7 +137,7 @@ interrupt_common:
         // might be on the NMI stack, but everything is stored safely
 	// in the ThreadState, thus we can switch to the bigger kernel
 	// stack now
-        // TODO check whether we actually could end up on the NMI stack when coming from user mode!!!
+        /// @todo check whether we actually could end up on the NMI stack when coming from user mode!!!
         mov %gs:kernel_stack, %rsp
         mov %rax, %rdi   // 1. argument: pointer to thread_state
         xor %rbp, %rbp

--- a/kernel/cpu/kernel-entry-amd64/cpu/irq_entry.S
+++ b/kernel/cpu/kernel-entry-amd64/cpu/irq_entry.S
@@ -32,7 +32,6 @@
 .extern kernel_stack
 .extern irq_entry_user
 .extern irq_entry_kernel
-.extern sleeping_failed
 
 // macro for interrupt entry without error code
 .macro INTERRUPT_ENTRY no
@@ -219,17 +218,3 @@ irq_return_user:
         mov TS_RDI(%rdi), %rdi
         swapgs  // restore user's GS base
         iretq   // return to user mode and enable interrupts via rflags IF field
-
-.global go_sleeping
-.type go_sleeping, @function
-go_sleeping:
-        mov %gs:kernel_stack, %rsp      // start on a clean stack to avoid filling it up
-        pushq   $0 // fake return address
-        pushq   $0 // fake rbp
-        sti
-        hlt
-        cli
-        xor %rbp, %rbp
-        pushq   $0 // fake return address
-        jmp sleeping_failed
-

--- a/kernel/cpu/kernel-entry-amd64/cpu/kernel_entry.cc
+++ b/kernel/cpu/kernel-entry-amd64/cpu/kernel_entry.cc
@@ -37,10 +37,14 @@ namespace mythos {
     void initSyscallEntry(uintptr_t stack) {
       kernel_stack.set(stack);
       thread_state.set(nullptr);
+      initSyscallEntry();
+    }
+
+    void initSyscallEntry() {
       x86::setStar(SEGMENT_KERNEL_CS, SEGMENT_USER_CS32+3);
       x86::setLStar(&syscall_entry);
       x86::setFMask(x86::FLAG_TF | x86::FLAG_DF | x86::FLAG_IF | x86::FLAG_IOPL);
-      x86::enableSyscalls();
+      //x86::setMSR(x86::MSR_EFER, x86::getMSR(x86::MSR_EFER) | x86::EFER_SCE); // done in start.S
     }
 
   } // namespace cpu

--- a/kernel/cpu/kernel-entry-amd64/cpu/kernel_entry.hh
+++ b/kernel/cpu/kernel-entry-amd64/cpu/kernel_entry.hh
@@ -98,8 +98,5 @@ namespace mythos {
      * defined by another model, used by irq_entry.S */
     void irq_entry_kernel(KernelIRQFrame*) SYMBOL("irq_entry_kernel");
 
-    NORETURN void go_sleeping() SYMBOL("go_sleeping");
-    NORETURN void sleeping_failed() SYMBOL("sleeping_failed");
-
   } // namespace cpu
 } // namespace mythos

--- a/kernel/cpu/kernel-entry-amd64/cpu/kernel_entry.hh
+++ b/kernel/cpu/kernel-entry-amd64/cpu/kernel_entry.hh
@@ -59,6 +59,7 @@ namespace mythos {
     extern CoreLocal<uintptr_t> kernel_stack SYMBOL("kernel_stack") KERNEL_CLM_HOT;
 
     void initSyscallEntry(uintptr_t stack);
+    void initSyscallEntry();
 
     // forward declaration
     extern void syscall_entry() SYMBOL("syscall_entry");

--- a/kernel/cpu/kernel-entry-amd64/mcconf.module
+++ b/kernel/cpu/kernel-entry-amd64/mcconf.module
@@ -5,4 +5,4 @@
     kernelfiles = [ "cpu/irq_entry.S", "cpu/syscall_entry.S", "cpu/kernel_entry.cc",
     "cpu/IdtAmd64.cc" ]
     requires = [ "symbol/irq_entry_kernel" ]
-    
+

--- a/kernel/cpu/lapic/cpu/LAPIC.cc
+++ b/kernel/cpu/lapic/cpu/LAPIC.cc
@@ -102,15 +102,15 @@ namespace mythos {
     ASSERT(getId() == x86::initialApicID());
 
     // init Error register
-    write(REG_ESR, 0); // Due to the Pentium erratum 3AP.
-    read(REG_ESR);
+    // write(REG_ESR, 0); // Due to the Pentium erratum 3AP.
+    // read(REG_ESR);
     value = read(REG_LVT_ERROR);
     value.vector = 0xFF; // should never happen because we leafe it masked
     value.masked = 1;
     write(REG_LVT_ERROR, value);
     // spec says clear errors after enabling vector.
-    write(REG_ESR, 0); // Due to the Pentium erratum 3AP.
-    read(REG_ESR);
+    // write(REG_ESR, 0); // Due to the Pentium erratum 3AP.
+    // read(REG_ESR);
   }
 
   void LAPIC::enablePeriodicTimer(uint8_t irq, uint32_t count) {
@@ -129,7 +129,7 @@ namespace mythos {
     write(REG_ESR, 0); // Be paranoid about clearing APIC errors.
     read(REG_ESR);
     writeIPI(0, edgeIPI(ICR_DESTSHORT_NOTSELF, MODE_INIT, 0));
-    hwthread_wait(10000);
+    //hwthread_wait(10000);
     return true;
   }
 

--- a/kernel/cpu/lapic/cpu/LAPIC.cc
+++ b/kernel/cpu/lapic/cpu/LAPIC.cc
@@ -102,15 +102,13 @@ namespace mythos {
     ASSERT(getId() == x86::initialApicID());
 
     // init Error register
-    // write(REG_ESR, 0); // Due to the Pentium erratum 3AP.
-    // read(REG_ESR);
+    write(REG_ESR, 0); read(REG_ESR); // Due to the Pentium erratum 3AP.
     value = read(REG_LVT_ERROR);
-    value.vector = 0xFF; // should never happen because we leafe it masked
+    value.vector = 0xFF; // should never happen because we leave it masked
     value.masked = 1;
     write(REG_LVT_ERROR, value);
     // spec says clear errors after enabling vector.
-    // write(REG_ESR, 0); // Due to the Pentium erratum 3AP.
-    // read(REG_ESR);
+    write(REG_ESR, 0); read(REG_ESR); // Due to the Pentium erratum 3AP.
   }
 
   void LAPIC::enablePeriodicTimer(uint8_t irq, uint32_t count) {

--- a/kernel/plugins/common/plugins/Plugin.hh
+++ b/kernel/plugins/common/plugins/Plugin.hh
@@ -33,6 +33,7 @@ namespace mythos {
   class IPlugin
   {
   public:
+    virtual ~IPlugin() {}
     virtual void initGlobal() {}
     virtual void initThread(size_t /*threadid*/) {}
   };
@@ -46,6 +47,7 @@ namespace mythos {
       this->next = first;
       first = this;
     }
+    virtual ~Plugin() {}
 
     static void initPluginsGlobal();
     static void initPluginsOnThread(size_t threadid);


### PR DESCRIPTION
Implements a hlt-based mechanism for x86 processors. The CC6 sleep on KNC probably works only for the C-Stepping. Next step is an emulation for KNC's deep sleep wakeup latency.