### PR TITLE
Issue 150: Enable out-of-tree build for MyThOS dependent projects

### DIFF
--- a/host-knc.config
+++ b/host-knc.config
@@ -19,3 +19,6 @@
       ]
 
     modules = [ "gitignore" ]
+
+[config.vars]
+    mythos_root = ".."

--- a/kernel-amd64.config
+++ b/kernel-amd64.config
@@ -34,3 +34,6 @@
       "plugin-cpudriver-knc",
       "app-init-example",
     ]
+
+[config.vars]
+    mythos_root = ".."

--- a/kernel-knc.config
+++ b/kernel-knc.config
@@ -29,3 +29,6 @@
       "app-init-example",
       "kernel-idle-knc",
     ]
+
+[config.vars]
+    mythos_root = ".."

--- a/kernel/build/emu-bochs-amd64/bochs.tmpl.rc
+++ b/kernel/build/emu-bochs-amd64/bochs.tmpl.rc
@@ -18,5 +18,3 @@ port_e9_hack: enabled=0
 #debug: action=report
 debug_symbols: file=boot.sym
 
-romimage: file="../3rdparty/bochs/bios/BIOS-bochs-latest"
-vgaromimage: file="../3rdparty/bochs/bios/VGABIOS-lgpl-latest"

--- a/kernel/build/emu-bochs-amd64/mcconf.module
+++ b/kernel/build/emu-bochs-amd64/mcconf.module
@@ -1,10 +1,15 @@
 # -*- mode:toml; -*-
 [module.bochs-emu-amd64]
-    incfiles = [ "bochs.rc" ]
+    incfiles = [ "bochs.tmpl.rc" ]
     requires = [ "boot.iso" ]
-    provides = [ "tag/emu-bochs" ]
+    provides = [ "tag/emu-bochs", "bochs.rc" ]
 
     makefile_body = '''
-bochs: boot.iso
-	../3rdparty/bochs/bochs -q -f bochs.rc
+bochs.rc: bochs.tmpl.rc
+	cat bochs.tmpl.rc > bochs.rc
+	echo 'romimage: file="${mythos_root}/3rdparty/bochs/bios/BIOS-bochs-latest"' >> bochs.rc
+	echo 'vgaromimage: file="${mythos_root}/3rdparty/bochs/bios/VGABIOS-lgpl-latest"' >> bochs.rc
+
+bochs: boot.iso bochs.rc
+	${mythos_root}/3rdparty/bochs/bochs -q -f bochs.rc
 '''

--- a/kernel/build/gcc-kernel-knc/mcconf.module
+++ b/kernel/build/gcc-kernel-knc/mcconf.module
@@ -73,7 +73,7 @@ APP_LDFLAGS = -g -static
 
     makefile_body = '''
 micrun: boot64.elf
-	sudo env LD_LIBRARY_PATH=$(LD_LIBRARY_PATH) ../host-knc/xmicterm 0 `pwd`/boot64.elf
+	sudo env LD_LIBRARY_PATH=$(LD_LIBRARY_PATH) ${mythos_root}/host-knc/xmicterm 0 `pwd`/boot64.elf
 
 micstop:
 	sudo micctrl -r --wait mic0


### PR DESCRIPTION
This change enables other projects to include mythos as a submodule and use McConf to generate a kernel configuration including the `bochs` and `micrun` target.