### PR TITLE
Use sink->write instead of mlog::app for debug syscall.

### DIFF
--- a/kernel/objects/execution-context/objects/ExecutionContext.cc
+++ b/kernel/objects/execution-context/objects/ExecutionContext.cc
@@ -375,7 +375,9 @@ namespace mythos {
       case SYSCALL_DEBUG: {
         MLOG_INFO(mlog::syscall, "debug", DVARhex(userctx), DVAR(portal));
         mlog::Logger<mlog::FilterAny> user("user");
-        user.error(mlog::DebugString((char const*)userctx, portal));
+        // userctx => address in memory
+        // portal => string length
+        mlog::sink->write((char const*)userctx, portal);
         code = uint64_t(Error::SUCCESS);
         break;
       }


### PR DESCRIPTION
Passing the debug syscall text through mlog makes it unsuited for csv/benchmark output.