### PR TITLE
I78 user state

### DIFF
--- a/kernel/boot/init-loader-amd64/boot/load_init.cc
+++ b/kernel/boot/init-loader-amd64/boot/load_init.cc
@@ -281,9 +281,9 @@ optional<void> InitLoader::createEC(uintptr_t ipc_vaddr)
   if (res) res = ec->setCapSpace(capAlloc.get(init::CSPACE));
   if (res) res = ec->setAddressSpace(capAlloc.get(init::PML4));
   if (res) res = ec->setSchedulingContext(capAlloc.get(init::SCHEDULERS_START));
-  if (res) res = ec->setStateFrame(capAlloc.get(init::STATE_FRAME), 0);
+  if (res) res = ec->setStateFrame(capAlloc.get(init::STATE_FRAME), 0, true);
   if (!res) RETHROW(res);
-  ec->getThreadState().rdi = ipc_vaddr;
+  ec->setRegParams(ipc_vaddr); // will be in rdi
   ec->setEntryPoint(_img.header()->entry);
   ec->setTrapped(false);
   RETURN(Error::SUCCESS);

--- a/kernel/cpu/fpu-amd64/cpu/fpu.cc
+++ b/kernel/cpu/fpu-amd64/cpu/fpu.cc
@@ -41,7 +41,7 @@ static uint32_t xstate_sizes[x86::XFeature::MAX];
 static uint32_t xstate_comp_offsets[x86::XFeature::MAX];
 
 enum FpuMode { FSAVE, FXSAVE, XSAVE, XSAVEOPT, XSAVES };
-static char const * const fpuModeNames[] = 
+static char const * const fpuModeNames[] =
   {"FSAVE", "FXSAVE", "XSAVE", "XSAVEOPT", "XSAVES"};
 static FpuMode fpu_mode = FSAVE;
 
@@ -49,7 +49,7 @@ static FpuMode fpu_mode = FSAVE;
 static void fpu_setup_xstate()
 {
   // ask cpuid for supported features
-  xfeatures_mask = x86::getXFeaturesMask(); 
+  xfeatures_mask = x86::getXFeaturesMask();
   mlog::boot.detail("xsave features from cpuid 0xd", DVARhex(xfeatures_mask));
   // and then disable features not supported by the processor
   if (!x86::hasFPU()) xfeatures_mask.fp = false;
@@ -88,7 +88,7 @@ static void fpu_setup_xstate()
   }
   PANIC(fpu_xstate_size <= sizeof(x86::FpuState));
   //do_extra_xstate_size_checks();
-  // for PT: update_regset_xstate_info(fpu_user_xstate_size,	xfeatures_mask & ~XFEATURE_MASK_SUPERVISOR);
+  // for PT: update_regset_xstate_info(fpu_user_xstate_size,    xfeatures_mask & ~XFEATURE_MASK_SUPERVISOR);
 
   // get the offsets and sizes of the state space
   xstate_offsets[0] = 0; // legacy FPU state
@@ -100,7 +100,7 @@ static void fpu_setup_xstate()
   auto last_good_offset = offsetof(x86::XRegs, extended_state_area); // beginnning of the "extended state"
   for (uint8_t idx = 2; idx < x86::XFeature::MAX; idx++) {
     if (!xfeatures_mask.enabled(idx)) continue;
-    xstate_offsets[idx] = (!x86::isXFeatureSupervisor(idx)) ? x86::getXFeatureOffset(idx) : 0; 
+    xstate_offsets[idx] = (!x86::isXFeatureSupervisor(idx)) ? x86::getXFeatureOffset(idx) : 0;
     xstate_sizes[idx] = x86::getXFeatureSize(idx);
     OOPS_MSG(last_good_offset <= xstate_offsets[idx], "cpu has misordered xstate");
     last_good_offset = xstate_offsets[idx];
@@ -132,7 +132,7 @@ static void fpu_setup_xstate()
   char const* names[] = {"x87", "mmx/sse", "ymm", "bndregs", "bndcsr", "opmask", "zmm_hi256", "hi16_zmm", "pt", "pkru"};
   for (uint8_t idx = 0; idx < x86::XFeature::MAX; idx++) {
     if (!xfeatures_mask.enabled(idx)) continue;
-    mlog::boot.detail("we support XSAVE feature", idx, names[idx], 
+    mlog::boot.detail("we support XSAVE feature", idx, names[idx],
       DVARhex(xstate_offsets[idx]), DVAR(xstate_sizes[idx]),
       DVARhex(xstate_comp_offsets[idx]), DVAR(xstate_comp_sizes[idx]));
   }
@@ -144,8 +144,8 @@ void FpuState::initBSP()
 
   mlog::boot.info("has x87 FPU:", DVAR(x86::hasMMX()), DVAR(x86::hasAVX()),
     DVAR(x86::hasAVX()&&x86::hasAVX512F()), DVAR(x86::hasXSAVE()),
-    DVAR(x86::hasXSAVE()&&x86::hasXSAVEC()), 
-    DVAR(x86::hasXSAVE()&&x86::hasXSAVEOPT()), 
+    DVAR(x86::hasXSAVE()&&x86::hasXSAVEC()),
+    DVAR(x86::hasXSAVE()&&x86::hasXSAVEOPT()),
     DVAR(x86::hasXSAVE()&&x86::hasXSAVES()));
 
   // initialise MXCR feature mask for fxsr
@@ -274,6 +274,11 @@ void FpuState::restore()
 void FpuState::clear()
 {
   memcpy(&state, &fpu_init_state, fpu_xstate_size);
+}
+
+size_t FpuState::size()
+{
+    return fpu_xstate_size;
 }
 
 } // namespace cpu

--- a/kernel/cpu/fpu-amd64/cpu/fpu.hh
+++ b/kernel/cpu/fpu-amd64/cpu/fpu.hh
@@ -44,13 +44,14 @@ namespace mythos {
       /** called during bootup on each processor. */
       static void initAP();
 
+      static size_t size();
 
       void clear();
       void save();
       void restore();
 
     public:
-      x86::FpuState state;      
+      x86::FpuState state;
     };
 
   } // namespace cpu

--- a/kernel/cpu/kernel-entry-amd64/cpu/irq_entry.S
+++ b/kernel/cpu/kernel-entry-amd64/cpu/irq_entry.S
@@ -134,8 +134,8 @@ interrupt_common:
         movq $0, TS_MAYSYSRET(%rax)
 
         // might be on the NMI stack, but everything is stored safely
-    // in the ThreadState, thus we can switch to the bigger kernel
-    // stack now
+        // in the ThreadState, thus we can switch to the bigger kernel
+        // stack now
         /// @todo check whether we actually could end up on the NMI stack when coming from user mode!!!
         mov %gs:kernel_stack, %rsp
         mov %rax, %rdi   // 1. argument: pointer to thread_state

--- a/kernel/cpu/kernel-entry-amd64/cpu/irq_entry.S
+++ b/kernel/cpu/kernel-entry-amd64/cpu/irq_entry.S
@@ -134,14 +134,16 @@ interrupt_common:
         movq $0, TS_MAYSYSRET(%rax)
 
         // might be on the NMI stack, but everything is stored safely
-	// in the ThreadState, thus we can switch to the bigger kernel
-	// stack now
+    // in the ThreadState, thus we can switch to the bigger kernel
+    // stack now
         /// @todo check whether we actually could end up on the NMI stack when coming from user mode!!!
         mov %gs:kernel_stack, %rsp
         mov %rax, %rdi   // 1. argument: pointer to thread_state
         xor %rbp, %rbp
         pushq   $0 // fake return address
-        jmp irq_entry_user
+        jmp irq_entry_user   // @todo as a call
+        // @todo call try to return to user via scheduler
+        // @todo call sleep if nothing to return to
 
 interrupt_kernel:
         xchg %bx, %bx
@@ -181,40 +183,3 @@ interrupt_kernel:
         pop %rcx
         add $(2*8), %rsp // pop irqno and error code
         iretq
-
-.global irq_return_user
-.type irq_return_user, @function
-irq_return_user:
-        xchg %bx, %bx
-        mov $IA32_FS_BASE, %rcx
-        mov TS_FS_BASE(%rdi), %eax
-        mov (TS_FS_BASE+4)(%rdi), %edx
-        wrmsr   // restore user's FS base
-        mov $IA32_KERNEL_GS_BASE, %rcx
-        mov TS_GS_BASE(%rdi), %eax
-        mov (TS_GS_BASE+4)(%rdi), %edx
-        wrmsr   // prepare user's GS base for swapgs
-        // create fake interrupt frame on the kernel stack
-        pushq $(SEGMENT_USER_DS+3)        // SS - user data segment with bottom 2 bits set for ring 3
-        pushq TS_RSP(%rdi)               // RSP - user stack from 2nd parameter
-        pushq TS_RFLAGS(%rdi)            // RFLAGS
-        pushq $(SEGMENT_USER_CS+3)        // CS  - user code segment with bottom 2 bits set for ring 3
-        pushq TS_RIP(%rdi)               // RIP - Instruction pointer after iretq
-        // restore all other register
-        mov TS_RAX(%rdi), %rax
-        mov TS_RBX(%rdi), %rbx
-        mov TS_RCX(%rdi), %rcx
-        mov TS_RDX(%rdi), %rdx
-        mov TS_RSI(%rdi), %rsi
-        mov TS_RBP(%rdi), %rbp
-        mov TS_R8(%rdi), %r8
-        mov TS_R9(%rdi), %r9
-        mov TS_R10(%rdi), %r10
-        mov TS_R11(%rdi), %r11
-        mov TS_R12(%rdi), %r12
-        mov TS_R13(%rdi), %r13
-        mov TS_R14(%rdi), %r14
-        mov TS_R15(%rdi), %r15
-        mov TS_RDI(%rdi), %rdi
-        swapgs  // restore user's GS base
-        iretq   // return to user mode and enable interrupts via rflags IF field

--- a/kernel/cpu/kernel-entry-amd64/cpu/kernel_entry.hh
+++ b/kernel/cpu/kernel-entry-amd64/cpu/kernel_entry.hh
@@ -71,20 +71,18 @@ namespace mythos {
     /** high-level syscall handler, must be defined by another module, used by syscall_entry.S */
     NORETURN void syscall_entry_cxx(ThreadState*) SYMBOL("syscall_entry_cxx");
 
-    /** return from syscall to user, defined in syscall_entry.S, reads state from thread_state */
-    NORETURN void syscall_return(ThreadState*) SYMBOL("syscall_return");
+    namespace internal {
+        /** return from syscall or interrupt to user, defined in syscall_entry.S, reads state from thread_state */
+        NORETURN void return_to_user_asm(ThreadState*) SYMBOL("return_to_user_asm");
+    } // namespace internal
 
     /** high-level irq handler when entering from user mode, must be
      * defined by another module, used by irq_entry.S */
     NORETURN void irq_entry_user(ThreadState*) SYMBOL("irq_entry_user");
 
-    /** return from interrupt to user, defined in irq_entry.S, reads state from thread_state */
-    NORETURN void irq_return_user(ThreadState*) SYMBOL("irq_return_user");
-
     NORETURN inline void return_to_user() {
-      ThreadState* s = thread_state.get();
-      if (s->maySysret && s->rip < 0x7FFFFFFFFFFF) syscall_return(s);
-      else irq_return_user(s);
+        // @todo handle case of nullptr -> sleep ???
+        internal::return_to_user_asm(thread_state.get());
     }
 
     /** Layout of the kernel's execution state on the interrupted kernel's stack.

--- a/kernel/cpu/kernel-entry-amd64/cpu/syscall_entry.S
+++ b/kernel/cpu/kernel-entry-amd64/cpu/syscall_entry.S
@@ -24,6 +24,7 @@
  * Copyright 2016 Randolf Rotta, Robert Kuban, Maik Krüger, and contributors, BTU Cottbus-Senftenberg
  */
 #include "cpu/thread-state-layout.h"
+#include "cpu/gdt-layout.h"
 
 .extern thread_state
 .extern kernel_stack
@@ -61,11 +62,14 @@ syscall_entry:
         mov %rax, %rdi   // 1. argument: pointer to thread_state
         xor %rbp, %rbp
         pushq   $0 // fake return address
-        jmp syscall_entry_cxx
+        jmp syscall_entry_cxx   // @todo as a call
+        // @todo call try to return to user via scheduler
+        // @todo call sleep if nothing to return to
 
-.global syscall_return
-.type syscall_return, @function
-syscall_return:
+.global return_to_user_asm
+.type return_to_user_asm, @function
+// RDI: ThreadState*
+return_to_user_asm:
         mov $IA32_FS_BASE, %rcx
         mov TS_FS_BASE(%rdi), %eax
         mov (TS_FS_BASE+4)(%rdi), %edx
@@ -74,24 +78,59 @@ syscall_return:
         mov TS_GS_BASE(%rdi), %eax
         mov (TS_GS_BASE+4)(%rdi), %edx
         wrmsr   // prepare user's GS base for swapgs
-        mov TS_RBP(%rdi), %rbp
-        /// @todo may use xor %reg,%reg to zero the unpreserved registers
-        /// @todo reorder thread-state-layout to reflect reduced register passing
-        //mov TS_RBX(%rdi), %rbx
-        //mov TS_R12(%rdi), %r12
-        //mov TS_R13(%rdi), %r13
-        //mov TS_R14(%rdi), %r14
-        //mov TS_R15(%rdi), %r15
-        // skip rcx (rcx contains user's rip)
-        //mov TS_RAX(%rdi), %rax          // may contain a return value now
-        //mov TS_RDX(%rdi), %rdx
-        mov TS_RSI(%rdi), %rsi
-        //mov TS_R8(%rdi), %r8
-        //mov TS_R9(%rdi), %r9
-        //mov TS_R10(%rdi), %r10
-        mov TS_RFLAGS(%rdi), %r11       // rflags
+
+        // check for save and fast sysret, otherwise do iret
+        // maysysret is nonzero and rip < 0x7FFFFFFFFFFF
+        movabs $0x7ffffffffffe,%rax
         mov TS_RIP(%rdi), %rcx          // instruction pointer
-        mov TS_RSP(%rdi), %rsp          // stack
-        mov TS_RDI(%rdi), %rdi
+        cmp %rax, %rcx
+        setbe %al
+        movzbl %al, %eax
+        test %rax, TS_MAYSYSRET(%rdi)   // flag for "came from syscall"
+        je return_from_irq
+
+        /// @todo reorder thread-state-layout to reflect reduced register passing
+        xor %rbx, %rbx
+        xor %r12, %r12
+        xor %r13, %r13
+        xor %r14, %r14
+        xor %r15, %r15
+        // skip rcx (rcx contains user's rip)
+        xor %rax, %rax
+        xor %rdx, %rdx
+        mov TS_RSI(%rdi), %rsi          // return value: user context
+        xor %r8, %r8
+        xor %r9, %r9
+        xor %r10, %r10
+        mov $0x000200, %r11             // don't trust the user's rflags, enforce interrupt enable flag
+        mov TS_RBP(%rdi), %rbp          // stack frame base pointer
+        mov TS_RSP(%rdi), %rsp          // top of stack
+        mov TS_RDI(%rdi), %rdi          // return value: state or error code
         swapgs                          // restore user's GS base
         sysretq
+
+return_from_irq:
+        // create fake interrupt frame on the kernel stack
+        pushq $(SEGMENT_USER_DS+3)      // SS - user data segment with bottom 2 bits set for ring 3
+        pushq TS_RSP(%rdi)              // RSP - user stack from 2nd parameter
+        pushq $0x000200                 // RFLAGS - don't trust the user's rflags, enforce interrupt enable flag
+        pushq $(SEGMENT_USER_CS+3)      // CS  - user code segment with bottom 2 bits set for ring 3
+        pushq %rcx                      // RIP - Instruction pointer after iretq
+        // restore all other register
+        mov TS_RAX(%rdi), %rax
+        mov TS_RBX(%rdi), %rbx
+        mov TS_RCX(%rdi), %rcx
+        mov TS_RDX(%rdi), %rdx
+        mov TS_RSI(%rdi), %rsi
+        mov TS_RBP(%rdi), %rbp
+        mov TS_R8(%rdi), %r8
+        mov TS_R9(%rdi), %r9
+        mov TS_R10(%rdi), %r10
+        mov TS_R11(%rdi), %r11
+        mov TS_R12(%rdi), %r12
+        mov TS_R13(%rdi), %r13
+        mov TS_R14(%rdi), %r14
+        mov TS_R15(%rdi), %r15
+        mov TS_RDI(%rdi), %rdi
+        swapgs  // restore user's GS base
+        iretq   // return to user mode and enable interrupts via rflags IF field

--- a/kernel/mythos/init/mythos/init.hh
+++ b/kernel/mythos/init/mythos/init.hh
@@ -39,6 +39,7 @@ namespace init {
     PML4,
     EC,
     PORTAL,
+    STATE_FRAME,
     EXAMPLE_FACTORY,
     MEMORY_REGION_FACTORY,
     EXECUTION_CONTEXT_FACTORY,

--- a/kernel/mythos/invocation/mythos/InvocationBuf.hh
+++ b/kernel/mythos/invocation/mythos/InvocationBuf.hh
@@ -48,8 +48,12 @@ namespace mythos{
 
     InvocationBase() : tag(0) {}
     InvocationBase(uint16_t label) : tag(0) { tag.label = label; }
-    InvocationBase(uint16_t label, uint8_t length, unsigned extraCaps=0) 
-      : tag(0) { tag = tag.label(label).length(length).extra_caps(extraCaps); }
+    InvocationBase(uint16_t label, uint8_t length, unsigned extraCaps=0)
+      : tag(0)
+    {
+      tag = tag.label(label).length(length).extra_caps(extraCaps);
+      ASSERT(extraCaps <= 6);
+    }
 
     Tag tag;           // 1x 4byte
     CapPtr dstPtr = null_cap;     // 1x 4byte

--- a/kernel/mythos/invocation/mythos/protocol/ExecutionContext.hh
+++ b/kernel/mythos/invocation/mythos/protocol/ExecutionContext.hh
@@ -46,17 +46,20 @@ namespace mythos {
       struct Configure : public InvocationBase {
         typedef InvocationBase response_type;
         constexpr static uint16_t label = (proto<<8) + CONFIGURE;
-        Configure(CapPtr as, CapPtr cs, CapPtr sched)
-          : InvocationBase(label,getLength(this))
+        Configure(CapPtr as, CapPtr cs, CapPtr sched, CapPtr state, uint32_t stateOffset)
+          : InvocationBase(label,getLength(this)), stateOffset(stateOffset)
         {
           addExtraCap(as);
           addExtraCap(cs);
           addExtraCap(sched);
+          addExtraCap(state);
         }
 
         CapPtr as() const { return this->capPtrs[0]; }
         CapPtr cs() const { return this->capPtrs[1]; }
         CapPtr sched() const { return this->capPtrs[2]; }
+        CapPtr state() const { return this->capPtrs[3]; }
+        uint32_t stateOffset;
       };
 
       struct Amd64Registers {
@@ -118,16 +121,22 @@ namespace mythos {
 
       struct Create : public KernelMemory::CreateBase {
         typedef InvocationBase response_type;
-        Create(CapPtr dst, CapPtr factory) 
-          : CreateBase(dst, factory, getLength(this), 3), start(false) { }
+        Create(CapPtr dst, CapPtr factory)
+          : CreateBase(dst, factory, getLength(this), 4)
+        {
+            as(null_cap); cs(null_cap); sched(null_cap); state(null_cap);
+        }
         Amd64Registers regs;
-        bool start;
+        bool start = {false};
+        uint32_t stateOffset = {0};
         CapPtr as() const { return this->capPtrs[2]; }
         CapPtr cs() const { return this->capPtrs[3]; }
         CapPtr sched() const { return this->capPtrs[4]; }
+        CapPtr state() const { return this->capPtrs[5]; }
         void as(CapPtr c) { this->capPtrs[2] = c; }
         void cs(CapPtr c) { this->capPtrs[3] = c; }
-        void sched(CapPtr c) { this->capPtrs[4] =c; }
+        void sched(CapPtr c) { this->capPtrs[4] = c; }
+        void state(CapPtr c) { this->capPtrs[5] = c; }
       };
 
       template<class IMPL, class... ARGS>

--- a/kernel/mythos/invocation/mythos/protocol/ExecutionContext.hh
+++ b/kernel/mythos/invocation/mythos/protocol/ExecutionContext.hh
@@ -46,8 +46,8 @@ namespace mythos {
       struct Configure : public InvocationBase {
         typedef InvocationBase response_type;
         constexpr static uint16_t label = (proto<<8) + CONFIGURE;
-        Configure(CapPtr as, CapPtr cs, CapPtr sched, CapPtr state, uint32_t stateOffset)
-          : InvocationBase(label,getLength(this)), stateOffset(stateOffset)
+        Configure(CapPtr as, CapPtr cs, CapPtr sched, CapPtr state, uint32_t stateOffset, bool initializeState)
+          : InvocationBase(label,getLength(this)), stateOffset(stateOffset), initializeState(initializeState)
         {
           addExtraCap(as);
           addExtraCap(cs);
@@ -60,6 +60,7 @@ namespace mythos {
         CapPtr sched() const { return this->capPtrs[2]; }
         CapPtr state() const { return this->capPtrs[3]; }
         uint32_t stateOffset;
+        bool initializeState;
       };
 
       struct Amd64Registers {
@@ -129,6 +130,7 @@ namespace mythos {
         Amd64Registers regs;
         bool start = {false};
         uint32_t stateOffset = {0};
+        bool initializeState = {true};
         CapPtr as() const { return this->capPtrs[2]; }
         CapPtr cs() const { return this->capPtrs[3]; }
         CapPtr sched() const { return this->capPtrs[4]; }

--- a/kernel/objects/capability-utils/objects/CapRef.cc
+++ b/kernel/objects/capability-utils/objects/CapRef.cc
@@ -34,7 +34,7 @@ namespace mythos {
     cap::resetReference(this->entry);
   }
 
-  optional<void> CapRefBase::set(void* subject, CapEntry& src, Cap srcCap)
+  optional<void> CapRefBase::set(void* subject, CapEntry& src, Cap srcCap, uint64_t extra)
   {
     this->reset();
     RETURN(cap::setReference(
@@ -43,7 +43,7 @@ namespace mythos {
         src, srcCap,
         [=](){
           this->orig.store(srcCap.asReference().value());
-          this->binding(subject, srcCap.asReference());
+          this->binding(subject, srcCap.asReference(), extra);
         }));
   }
 

--- a/kernel/objects/execution-context/objects/ExecutionContext.cc
+++ b/kernel/objects/execution-context/objects/ExecutionContext.cc
@@ -158,7 +158,8 @@ namespace mythos {
     if (!obj) RETHROW(obj);
     auto info = obj.getFrameInfo();
     if (info.device || !info.writable) THROW(Error::INVALID_CAPABILITY);
-    if (offset+sizeof(State) >= info.size) THROW(Error::INSUFFICIENT_RESOURCES);
+    size_t size = round_up(sizeof(cpu::ThreadState), alignof(cpu::FpuState)) + cpu::FpuState::size();
+    if (offset+size >= info.size) THROW(Error::INSUFFICIENT_RESOURCES);
     RETURN(_state.set(this, *framecapref, obj.cap(), info.start.logint()+offset));
   }
 

--- a/kernel/objects/execution-context/objects/ExecutionContext.hh
+++ b/kernel/objects/execution-context/objects/ExecutionContext.hh
@@ -69,7 +69,7 @@ namespace mythos {
       NOT_LOADED   = 1<<8, // CPU state is not loaded
       DONT_PREEMPT  = 1<<9, // somebody else will send the preemption
       NOT_RUNNING  = 1<<10, // EC is not running
-      BLOCK_MASK = IS_WAITING | IS_TRAPPED | NO_AS | NO_SCHED /*| NO_STATE */| REGISTER_ACCESS,
+      BLOCK_MASK = IS_WAITING | IS_TRAPPED | NO_AS | NO_SCHED | NO_STATE | REGISTER_ACCESS,
       INIT_FLAGS = IS_TRAPPED | NO_AS | NO_SCHED | NO_STATE | DONT_PREEMPT | NOT_LOADED | NOT_RUNNING
     };
 
@@ -89,13 +89,14 @@ namespace mythos {
     optional<void> setCapSpace(optional<CapEntry*> capmapref);
     void unsetCapSpace() { _cs.reset(); }
 
-    optional<void> setStateFrame(optional<CapEntry*> framecapref, uint32_t offset);
+    optional<void> setStateFrame(optional<CapEntry*> framecapref, uint32_t offset, bool initializeState);
     void unsetStateFrame() { _state.reset(); }
 
     void setEntryPoint(uintptr_t rip);
     void setTrapped(bool val);
 
-    cpu::ThreadState& getThreadState() { return threadState; }
+    //cpu::ThreadState& getThreadState() { return threadState; }
+    void setRegParams(uint64_t rdi);
 
     optional<void> setRegisters(const mythos::protocol::ExecutionContext::Amd64Registers&);
     optional<void> setBaseRegisters(uint64_t fs_base, uint64_t gs_base);
@@ -197,9 +198,6 @@ namespace mythos {
       cpu::FpuState fpuState;
     };
     State* state = {nullptr}; // cached value from _state+offset
-
-    cpu::ThreadState threadState;
-    cpu::FpuState fpuState;
 
     LinkedList<IKernelObject*>::Queueable del_handle = {this};
     IAsyncFree* memory;

--- a/kernel/objects/execution-context/objects/ExecutionContext.hh
+++ b/kernel/objects/execution-context/objects/ExecutionContext.hh
@@ -70,7 +70,7 @@ namespace mythos {
       DONT_PREEMPT  = 1<<9, // somebody else will send the preemption
       NOT_RUNNING  = 1<<10, // EC is not running
       BLOCK_MASK = IS_WAITING | IS_TRAPPED | NO_AS | NO_SCHED /*| NO_STATE */| REGISTER_ACCESS,
-      INIT_FLAGS = IS_TRAPPED | NO_AS | NO_SCHED /*| NO_STATE */| DONT_PREEMPT | NOT_LOADED | NOT_RUNNING
+      INIT_FLAGS = IS_TRAPPED | NO_AS | NO_SCHED | NO_STATE | DONT_PREEMPT | NOT_LOADED | NOT_RUNNING
     };
 
     ExecutionContext(IAsyncFree* memory);

--- a/kernel/objects/execution-context/objects/ExecutionContext.hh
+++ b/kernel/objects/execution-context/objects/ExecutionContext.hh
@@ -67,7 +67,8 @@ namespace mythos {
       NOT_LOADED   = 1<<8, // CPU state is not loaded
       DONT_PREEMPT  = 1<<9, // somebody else will send the preemption
       NOT_RUNNING  = 1<<10, // EC is not running
-      BLOCK_MASK = IS_WAITING | IS_TRAPPED | NO_AS | NO_SCHED | REGISTER_ACCESS
+      BLOCK_MASK = IS_WAITING | IS_TRAPPED | NO_AS | NO_SCHED | REGISTER_ACCESS,
+      INIT_FLAGS = IS_TRAPPED | NO_AS | NO_SCHED | DONT_PREEMPT | NOT_LOADED | NOT_RUNNING
     };
 
     ExecutionContext(IAsyncFree* memory);
@@ -157,7 +158,7 @@ namespace mythos {
   private:
     async::NestedMonitorDelegating monitor;
     INotifiable::list_t notificationQueue;
-    std::atomic<flag_t> flags;
+    std::atomic<flag_t> flags = {INIT_FLAGS};
     CapRef<ExecutionContext,IPageMap> _as;
     CapRef<ExecutionContext,ICapMap> _cs;
     CapRef<ExecutionContext,IScheduler> _sched;

--- a/kernel/objects/execution-context/objects/ExecutionContext.hh
+++ b/kernel/objects/execution-context/objects/ExecutionContext.hh
@@ -149,7 +149,7 @@ namespace mythos {
 
   protected:
     friend class CapRefBind;
-    void bind(optional<IPageMap*>, uint64_t);
+    void bind(optional<IPageMap*>, uint64_t tableAddr);
     void bind(optional<ICapMap*>, uint64_t) {}
     void bind(optional<IScheduler*>, uint64_t);
     void bind(optional<IFrame*>, uint64_t stateAddr);
@@ -198,6 +198,7 @@ namespace mythos {
       cpu::FpuState fpuState;
     };
     State* state = {nullptr}; // cached value from _state+offset
+    PhysPtr<void> page_table; // cached pml4, address space
 
     LinkedList<IKernelObject*>::Queueable del_handle = {this};
     IAsyncFree* memory;

--- a/kernel/objects/execution-context/objects/ExecutionContext.hh
+++ b/kernel/objects/execution-context/objects/ExecutionContext.hh
@@ -36,6 +36,7 @@
 #include "objects/IScheduler.hh"
 #include "objects/IFactory.hh"
 #include "objects/IPageMap.hh"
+#include "objects/IFrame.hh"
 #include "objects/INotifiable.hh"
 #include "objects/ISignalable.hh"
 #include "objects/IPortal.hh"
@@ -61,29 +62,35 @@ namespace mythos {
       IS_TRAPPED = 1<<1, // used by suspend/resume invocations and trap/exception handler
       NO_AS      = 1<<2, // set if address space is missing
       NO_SCHED   = 1<<3, // set if scheduler is missing
+      NO_STATE   = 1<<4, // set if frame for the state data is missing
       IN_WAIT    = 1<<5, // EC is in wait() syscall, next sysret should return a KEvent
       IS_NOTIFIED     = 1<<6, // used by notify() syscall for binary semaphore
       REGISTER_ACCESS = 1<<7, // accessing registers
       NOT_LOADED   = 1<<8, // CPU state is not loaded
       DONT_PREEMPT  = 1<<9, // somebody else will send the preemption
       NOT_RUNNING  = 1<<10, // EC is not running
-      BLOCK_MASK = IS_WAITING | IS_TRAPPED | NO_AS | NO_SCHED | REGISTER_ACCESS,
-      INIT_FLAGS = IS_TRAPPED | NO_AS | NO_SCHED | DONT_PREEMPT | NOT_LOADED | NOT_RUNNING
+      BLOCK_MASK = IS_WAITING | IS_TRAPPED | NO_AS | NO_SCHED /*| NO_STATE */| REGISTER_ACCESS,
+      INIT_FLAGS = IS_TRAPPED | NO_AS | NO_SCHED /*| NO_STATE */| DONT_PREEMPT | NOT_LOADED | NOT_RUNNING
     };
 
     ExecutionContext(IAsyncFree* memory);
     virtual ~ExecutionContext() {}
 
+  public: // only for initial setup
+    optional<void> setSchedulingContext(optional<CapEntry*> sce);
+
+  public:
     optional<void> setAddressSpace(optional<CapEntry*> pagemapref);
     void unsetAddressSpace() { _as.reset(); }
 
-    /// only for initial setup
-    optional<void> setSchedulingContext(optional<CapEntry*> sce);
     optional<void> setSchedulingContext(Tasklet* t, IInvocation* msg, optional<CapEntry*> sce);
-    Error unsetSchedulingContext();
+    void unsetSchedulingContext() { _sched.reset(); }
 
     optional<void> setCapSpace(optional<CapEntry*> capmapref);
     void unsetCapSpace() { _cs.reset(); }
+
+    optional<void> setStateFrame(optional<CapEntry*> framecapref, uint32_t offset);
+    void unsetStateFrame() { _state.reset(); }
 
     void setEntryPoint(uintptr_t rip);
     void setTrapped(bool val);
@@ -141,19 +148,27 @@ namespace mythos {
 
   protected:
     friend class CapRefBind;
-    void bind(optional<IPageMap*>);
-    void bind(optional<ICapMap*>) {}
-    void bind(optional<IScheduler*>);
+    void bind(optional<IPageMap*>, uint64_t);
+    void bind(optional<ICapMap*>, uint64_t) {}
+    void bind(optional<IScheduler*>, uint64_t);
+    void bind(optional<IFrame*>, uint64_t stateAddr);
     void unbind(optional<IPageMap*>);
     void unbind(optional<ICapMap*>) {}
     void unbind(optional<IScheduler*>);
+    void unbind(optional<IFrame*>);
 
     flag_t setFlags(flag_t f) { return flags.fetch_or(f); }
     flag_t clearFlags(flag_t f) { return flags.fetch_and(flag_t(~f)); }
-    void setFlagsSuspend(flag_t f);
-    void clearFlagsResume(flag_t f);
     bool isBlocked(flag_t f) const { return (f & BLOCK_MASK) != 0; }
     bool needPreemption(flag_t f) const { return (f & DONT_PREEMPT) == 0; }
+
+    /** Sets some flags and suspends the thread if a blocking condition is reached.
+     * Returns synchronously after the thread has suspended independent of
+     * the place that changes the flags and the place where the thread currently runs.
+     */
+    void setFlagsSuspend(flag_t f);
+
+    void clearFlagsResume(flag_t f);
 
   private:
     async::NestedMonitorDelegating monitor;
@@ -162,6 +177,7 @@ namespace mythos {
     CapRef<ExecutionContext,IPageMap> _as;
     CapRef<ExecutionContext,ICapMap> _cs;
     CapRef<ExecutionContext,IScheduler> _sched;
+    CapRef<ExecutionContext,IFrame> _state; // will contain threadState and fpuState
     /// @todo reference/link to exception handler (portal/endpoint?)
 
     // the hardware thread where the fpu state is currently loaded
@@ -175,6 +191,12 @@ namespace mythos {
       writeSleepResponse = {this};
     async::MSink<ExecutionContext, void, &ExecutionContext::suspendThread>
       sleepResponse = {this};
+
+    struct State {
+      cpu::ThreadState threadState;
+      cpu::FpuState fpuState;
+    };
+    State* state = {nullptr}; // cached value from _state+offset
 
     cpu::ThreadState threadState;
     cpu::FpuState fpuState;

--- a/kernel/objects/interrupt-control/objects/InterruptControl.hh
+++ b/kernel/objects/interrupt-control/objects/InterruptControl.hh
@@ -44,12 +44,12 @@ public: // IKernelObject interface
     optional<void> deleteCap(CapEntry&, Cap self, IDeleter& del) override;
     void invoke(Tasklet* t, Cap, IInvocation* msg) override;
 public: // for CapRef
-    void bind(optional<ISignalable*>) { }
+    void bind(optional<ISignalable*>, uint64_t) { }
     void unbind(optional<ISignalable*>) {
         // triggered by cap revoke
         // TODO would need to revoke notification if we use INotifiable instead of ISignalable
     }
-public: // protocol 
+public: // protocol
     friend struct protocol::KernelObject;
     Error getDebugInfo(Cap self, IInvocation* msg);
     Error registerForInterrupt(Tasklet *t, Cap self, IInvocation *msg);

--- a/kernel/objects/portal/objects/Portal.cc
+++ b/kernel/objects/portal/objects/Portal.cc
@@ -40,20 +40,19 @@ namespace mythos {
     auto info = frame.getFrameInfo();
     if (info.device || !info.writable) THROW(Error::INVALID_CAPABILITY);
     if (offset+sizeof(InvocationBuf) >= info.size) THROW(Error::INSUFFICIENT_RESOURCES);
-    ibNew = reinterpret_cast<InvocationBuf*>(info.start.logint()+offset);
-    RETURN(_ib.set(this, *fe, frame.cap()));
+    RETURN(_ib.set(this, *fe, frame.cap(), info.start.logint()+offset));
   }
 
-  void Portal::bind(optional<IFrame*> obj)
+  void Portal::bind(optional<IFrame*>, uint64_t ibAddr)
   {
     MLOG_INFO(mlog::portal, "Portal::setInvocationBuf bind");
-    if (obj) ib = ibNew;
+    ib = reinterpret_cast<InvocationBuf*>(ibAddr);
   }
 
   void Portal::unbind(optional<IFrame*>)
   {
     MLOG_INFO(mlog::portal, "Portal::setInvocationBuf unbind");
-    ib = nullptr; // but do not overwrite ibNew before the bind() method!
+    ib = nullptr;
   }
 
   optional<void> Portal::setOwner(optional<CapEntry*> ece)

--- a/kernel/objects/portal/objects/Portal.hh
+++ b/kernel/objects/portal/objects/Portal.hh
@@ -130,15 +130,14 @@ namespace mythos {
 
   protected:
     friend class CapRefBind;
-    void bind(optional<IFrame*>);
-    void bind(optional<IPortalUser*>) {}
+    void bind(optional<IFrame*>, uint64_t ibAddr);
+    void bind(optional<IPortalUser*>, uint64_t) {}
     void unbind(optional<IFrame*>);
     void unbind(optional<IPortalUser*>);
 
   private:
     CapRef<Portal, IFrame> _ib;
-    InvocationBuf* ib = nullptr;
-    InvocationBuf* ibNew = nullptr;
+    InvocationBuf* ib = nullptr; // cached value from _ib+offset
     CapRef<Portal, IPortalUser> _owner;
     uintptr_t uctx = 0;
     INotifiable::handle_t notificationHandle = {this};

--- a/kernel/runtime/kobject/runtime/ExecutionContext.hh
+++ b/kernel/runtime/kobject/runtime/ExecutionContext.hh
@@ -121,8 +121,8 @@ namespace mythos {
         return {this->cap(), kmem.cap(), factory};
     }
 
-    PortalFuture<void> configure(PortalLock pr, PageMap as, CapMap cs, CapPtr sched, CapPtr state, uint32_t stateOffset) {
-      return pr.invoke<protocol::ExecutionContext::Configure>(_cap, as.cap(), cs.cap(), sched, state, stateOffset);
+    PortalFuture<void> configure(PortalLock pr, PageMap as, CapMap cs, CapPtr sched, CapPtr state, uint32_t stateOffset, bool initializeState) {
+      return pr.invoke<protocol::ExecutionContext::Configure>(_cap, as.cap(), cs.cap(), sched, state, stateOffset, initializeState);
     }
 
     struct Registers : register_t {

--- a/kernel/runtime/kobject/runtime/ExecutionContext.hh
+++ b/kernel/runtime/kobject/runtime/ExecutionContext.hh
@@ -33,11 +33,11 @@
 #include "mythos/init.hh"
 
 namespace mythos {
-    
+
     extern thread_local CapPtr localEC;
 
     template<class MSG> class Msg;
-    
+
     template<> class Msg<protocol::ExecutionContext::Create>
     {
     protected:
@@ -46,64 +46,65 @@ namespace mythos {
     public:
         typedef void* (*StartFun)(void*);
         typedef int (*StartFunInt)(void*);
-        
+
         Msg(CapPtr dst, CapPtr kmem, CapPtr factory) : ib(dst, factory), obj(kmem) {}
-        
+
         Msg& as(CapPtr c) { ib.as(c); return *this; }
         Msg& as(PageMap& c) { ib.as(c.cap()); return *this; }
         Msg& cs(CapPtr c) { ib.cs(c); return *this; }
         Msg& cs(CapMap& c) { ib.cs(c.cap()); return *this; }
         Msg& sched(CapPtr c) { ib.sched(c); return *this; }
+        Msg& state(CapPtr c, uint32_t offset) { ib.state(c); ib.stateOffset = offset; return *this; }
         Msg& rawStack(void* ptr) { ib.regs.rsp = uintptr_t(ptr); return *this; }
         Msg& prepareStack(void* ptr) {
             // \TODO assert alignment
             auto tos = reinterpret_cast<uintptr_t*>(ptr);
             *--tos = 0;                                     // dummy return address
-            ib.regs.rsp = uintptr_t(tos); 
-            return *this; 
+            ib.regs.rsp = uintptr_t(tos);
+            return *this;
         }
-        Msg& startFun(StartFun fun, void* userctx, CapPtr ec) { 
+        Msg& startFun(StartFun fun, void* userctx, CapPtr ec) {
             ib.regs.rdi = uintptr_t(fun);                   // arg 1
             ib.regs.rsi = uintptr_t(userctx);               // arg 2
-            ib.regs.rdx = uintptr_t(ec);               	    // arg 3
+            ib.regs.rdx = uintptr_t(ec);                    // arg 3
             ib.regs.rip = uintptr_t(&start);
-            return *this; 
+            return *this;
         }
 
-        Msg& startFunInt(StartFunInt fun, void* userctx, CapPtr ec) { 
+        Msg& startFunInt(StartFunInt fun, void* userctx, CapPtr ec) {
             ib.regs.rdi = uintptr_t(fun);                   // arg 1
             ib.regs.rsi = uintptr_t(userctx);               // arg 2
             ib.regs.rdx = uintptr_t(ec);                    // arg 3
             ib.regs.rip = uintptr_t(&startInt);
-            return *this; 
+            return *this;
         }
 
         Msg& suspended(bool value) { ib.start = !value; return *this; }
         Msg& fs(void* ptr) { ib.regs.fs_base = uintptr_t(ptr); return *this; }
         Msg& gs(void* ptr) { ib.regs.gs_base = uintptr_t(ptr); return *this; }
-        
+
         // inherited from KernelMemory::CreateBase
         Msg& indirectDest(CapPtr dstCSpace, CapPtrDepth dstDepth) {
             ib.setIndirectDest(dstCSpace, dstDepth);
             return *this;
         }
-        
-        PortalFuture<void> invokeVia(PortalLock pl) { 
-            
-            return std::move(pl.invokeWithMsg(obj,  ib)); 
+
+        PortalFuture<void> invokeVia(PortalLock pl) {
+
+            return std::move(pl.invokeWithMsg(obj,  ib));
         }
 
     protected:
-        static void start(StartFun main, void* userctx, CapPtr ec) { 
+        static void start(StartFun main, void* userctx, CapPtr ec) {
             localEC = ec;
             syscall_exit(uintptr_t(main(userctx)));
         }
 
-        static void startInt(StartFunInt main, void* userctx, CapPtr ec) { 
+        static void startInt(StartFunInt main, void* userctx, CapPtr ec) {
             localEC = ec;
             syscall_exit(main(userctx));
         }
-    };    
+    };
 
 
   class ExecutionContext : public KObject
@@ -114,14 +115,14 @@ namespace mythos {
 
     ExecutionContext() {}
     ExecutionContext(CapPtr cap) : KObject(cap) {}
-    
-    Msg<protocol::ExecutionContext::Create> 
+
+    Msg<protocol::ExecutionContext::Create>
     create(KernelMemory kmem, CapPtr factory = init::EXECUTION_CONTEXT_FACTORY) {
         return {this->cap(), kmem.cap(), factory};
     }
 
-    PortalFuture<void> configure(PortalLock pr, PageMap as, CapMap cs, CapPtr sched) {
-      return pr.invoke<protocol::ExecutionContext::Configure>(_cap, as.cap(), cs.cap(), sched);
+    PortalFuture<void> configure(PortalLock pr, PageMap as, CapMap cs, CapPtr sched, CapPtr state, uint32_t stateOffset) {
+      return pr.invoke<protocol::ExecutionContext::Configure>(_cap, as.cap(), cs.cap(), sched, state, stateOffset);
     }
 
     struct Registers : register_t {


### PR DESCRIPTION
Store state of execution contexts in user accessible memory frames. This includes the CPU and FPU registers. The objective is to enable easier access to suspended threads for user-mode trap handlers and thread management.

Integration into the musl pthreads support code is still pending.