### PR TITLE
renaming .init with .bootlower

### DIFF
--- a/kernel/boot/kernel-amd64-ihk/boot/start.S
+++ b/kernel/boot/kernel-amd64-ihk/boot/start.S
@@ -31,7 +31,7 @@
 .extern entry_bsp
 .extern entry_ap
 
-.section .init, "awx"  // the following code and data is in the low memory init section
+.section .bootlower, "awx"  // the following code and data is in the low memory init section
 
 // EFER bit 0: SYSCALL instruction enable
 // EFER bit 8: IA-32e mode enable

--- a/kernel/boot/kernel-amd64-knc/boot/boot.ld
+++ b/kernel/boot/kernel-amd64-knc/boot/boot.ld
@@ -49,8 +49,8 @@ SECTIONS
     /* load the boot code at VMA=LMA LOAD_ADDR */
     .init LOAD_ADDR : AT(LOAD_ADDR)
     {
-        KEEP(*(.init))
-    } : init /* put into init segment */
+        KEEP(*(.bootlower))
+    } : bootlower /* put into init segment */
     PROVIDE (LOAD_END = .);
 
     /* the begin of the upper half code and data in physical memory */

--- a/kernel/boot/kernel-amd64-knc/boot/start.S
+++ b/kernel/boot/kernel-amd64-knc/boot/start.S
@@ -31,7 +31,7 @@
 .extern entry_bsp
 .extern entry_ap
 
-.section .init, "awx"  // the following code and data is in the low memory init section
+.section .bootlower, "awx"  // the following code and data is in the low memory init section
 
 // EFER bit 0: SYSCALL instruction enable
 // EFER bit 8: IA-32e mode enable

--- a/kernel/boot/kernel-amd64-pc/boot/boot.ld
+++ b/kernel/boot/kernel-amd64-pc/boot/boot.ld
@@ -45,12 +45,12 @@ PHDRS
 
 SECTIONS
 {
-    /* LOAD_ADDR is begin of the init code and data */
+    /* LOAD_ADDR is begin of the lower half boot code and data */
     /* load the boot code at VMA=LMA LOAD_ADDR */
     .bootlower LOAD_ADDR : AT(LOAD_ADDR)
     {
         KEEP(*(.bootlower))
-    } : bootlower /* put into init segment */
+    } : bootlower /* put into boot segment */
     PROVIDE (LOAD_END = .);
 
     /* the begin of the upper half code and data in physical memory */

--- a/kernel/boot/kernel-amd64-pc/boot/boot.ld
+++ b/kernel/boot/kernel-amd64-pc/boot/boot.ld
@@ -38,7 +38,7 @@ ENTRY(_start_bsp)
  */
 PHDRS
 {
-    init PT_LOAD;
+    bootlower PT_LOAD;
     kern PT_LOAD;
     data PT_LOAD;
 }
@@ -47,10 +47,10 @@ SECTIONS
 {
     /* LOAD_ADDR is begin of the init code and data */
     /* load the boot code at VMA=LMA LOAD_ADDR */
-    .init LOAD_ADDR : AT(LOAD_ADDR)
+    .bootlower LOAD_ADDR : AT(LOAD_ADDR)
     {
-        KEEP(*(.init))
-    } : init /* put into init segment */
+        KEEP(*(.bootlower))
+    } : bootlower /* put into init segment */
     PROVIDE (LOAD_END = .);
 
     /* the begin of the upper half code and data in physical memory */

--- a/kernel/boot/kernel-amd64-pc/boot/start.S
+++ b/kernel/boot/kernel-amd64-pc/boot/start.S
@@ -31,7 +31,7 @@
 .extern entry_bsp
 .extern entry_ap
 
-.section .init, "awx"  // the following code and data is in the low memory init section
+.section .bootlower, "awx"  // the following code and data is in the low memory init section
 
 // EFER bit 0: SYSCALL instruction enable
 // EFER bit 8: IA-32e mode enable

--- a/kernel/build/gcc-host-pc/util/compiler.hh
+++ b/kernel/build/gcc-host-pc/util/compiler.hh
@@ -30,8 +30,6 @@
 #define ALIGNED(X)          alignas(X)
 #define ALIGN_4K            alignas(4096)
 #define ALWAYS_INLINE       __attribute__((always_inline))
-#define INIT                __attribute__((section (".bootlower")))
-#define INITDATA            __attribute__((section (".initdata")))
 #define NORETURN            [[noreturn]]
 //__attribute__((noreturn))
 #define NOINLINE            __attribute__((noinline))

--- a/kernel/build/gcc-host-pc/util/compiler.hh
+++ b/kernel/build/gcc-host-pc/util/compiler.hh
@@ -30,7 +30,7 @@
 #define ALIGNED(X)          alignas(X)
 #define ALIGN_4K            alignas(4096)
 #define ALWAYS_INLINE       __attribute__((always_inline))
-#define INIT                __attribute__((section (".init")))
+#define INIT                __attribute__((section (".bootlower")))
 #define INITDATA            __attribute__((section (".initdata")))
 #define NORETURN            [[noreturn]]
 //__attribute__((noreturn))

--- a/kernel/build/gcc-kernel-knc/util/compiler.hh
+++ b/kernel/build/gcc-kernel-knc/util/compiler.hh
@@ -30,8 +30,6 @@
 #define ALIGNED(X)          alignas(X)
 #define ALIGN_4K            alignas(4096)
 #define ALWAYS_INLINE       __attribute__((always_inline))
-// #define INIT                __attribute__((section (".init")))
-// #define INITDATA            __attribute__((section (".initdata")))
 #define NORETURN            [[noreturn]]
 //__attribute__((noreturn))
 #define NOINLINE            __attribute__((noinline))

--- a/kernel/build/gcc-kernel-pc/util/compiler.hh
+++ b/kernel/build/gcc-kernel-pc/util/compiler.hh
@@ -30,8 +30,6 @@
 #define ALIGNED(X)          alignas(X)
 #define ALIGN_4K            alignas(4096)
 #define ALWAYS_INLINE       __attribute__((always_inline))
-// #define INIT                __attribute__((section (".init")))
-// #define INITDATA            __attribute__((section (".initdata")))
 #define NORETURN            [[noreturn]]
 //__attribute__((noreturn))
 #define NOINLINE            __attribute__((noinline))

--- a/kernel/runtime/crt-init/runtime/crtend.S
+++ b/kernel/runtime/crt-init/runtime/crtend.S
@@ -24,7 +24,7 @@
  * Copyright 2016 Randolf Rotta, Robert Kuban, and contributors, BTU Cottbus-Senftenberg
  */
 
-.section .bootlower
+.section .init
 	pop %rbp
 	ret
 

--- a/kernel/runtime/crt-init/runtime/crtend.S
+++ b/kernel/runtime/crt-init/runtime/crtend.S
@@ -24,7 +24,7 @@
  * Copyright 2016 Randolf Rotta, Robert Kuban, and contributors, BTU Cottbus-Senftenberg
  */
 
-.section .init
+.section .bootlower
 	pop %rbp
 	ret
 

--- a/kernel/runtime/crt-init/runtime/start.S
+++ b/kernel/runtime/crt-init/runtime/start.S
@@ -53,10 +53,10 @@ __dso_handle:
 .skip  8
 .hidden __dso_handle
 
-.section .init
-.global _init
-.type _init,@function
-_init:
+.section .bootlower
+.global _bootlower
+.type _bootlower,@function
+_bootlower:
         push %rbp
         mov %rsp, %rbp
 

--- a/kernel/runtime/crt-init/runtime/start.S
+++ b/kernel/runtime/crt-init/runtime/start.S
@@ -35,13 +35,9 @@
 _start:
         mov initstack_top, %rsp
         xor %rbp, %rbp
-        mov %rdi, msg_ptr       // store first argument to global variable
-/*        fninit                  // initialize the FPU
-        call __libc_init_array*/
+        mov %rdi, msg_ptr       /* store first argument to global variable */
         call start_c
-/*        mov $0, %rdi
-        call exit
-1:      jmp 1b*/
+1:      jmp 1b                  /* should never return from start_c anyway */
 
 /* A handle for __cxa_finalize to manage c++ local destructors.  */
 .global __dso_handle


### PR DESCRIPTION
Tested with Qemu and IHK. 
Could not test it with KNC yet, because of a compiler error.