### PR TITLE
I123 rename init

### DIFF
--- a/kernel/boot/kernel-amd64-ihk/boot/start.S
+++ b/kernel/boot/kernel-amd64-ihk/boot/start.S
@@ -31,7 +31,7 @@
 .extern entry_bsp
 .extern entry_ap
 
-.section .init, "awx"  // the following code and data is in the low memory init section
+.section .bootlower, "awx"  // the following code and data is in the low memory init section
 
 // EFER bit 0: SYSCALL instruction enable
 // EFER bit 8: IA-32e mode enable

--- a/kernel/boot/kernel-amd64-ihk/boot/start.S
+++ b/kernel/boot/kernel-amd64-ihk/boot/start.S
@@ -31,8 +31,6 @@
 .extern entry_bsp
 .extern entry_ap
 
-.section .bootlower, "awx"  // the following code and data is in the low memory init section
-
 // EFER bit 0: SYSCALL instruction enable
 // EFER bit 8: IA-32e mode enable
 // EFER bit 11: enable noexecute bit in page tables
@@ -64,125 +62,6 @@
 #define CR4_MASK     0xFFFFFFFF
 #define CR4_ENABLE   0x00000020
 
-/** magic number for the Multiboot header. */
-#define MULTIBOOT_HEADER_MAGIC          0x1BADB002
-
-/** multiboot flags towards the bootloader.
- *
- * https://www.gnu.org/software/grub/manual/multiboot/multiboot.html
- * If bit 0 in the ‘flags’ word is set, then all boot modules loaded along with the operating system must be aligned on page (4KB) boundaries.
- * If bit 1 in the ‘flags’ word is set, then information on available memory via at least the ‘mem_*’ fields of the Multiboot information structure must be included. If the boot loader is capable of passing a memory map (the ‘mmap_*’ fields) and one exists, then it may be included as well.
- * If bit 2 in the ‘flags’ word is set, information about the video mode table must be available to the kernel.
- * If bit 16 in the ‘flags’ word is set, then the fields at offsets 12-28 in the Multiboot header are valid, and the boot loader should use them instead of the fields in the actual executable header to calculate where to load the OS image. This information does not need to be provided if the kernel image is in elf format.
- */
-#define MULTIBOOT_HEADER_FLAGS          0x00000000
-
-.align  4
-/** multiboot header: just magic, flags and checksum without the optional fields */
-/*_mboot_header:
-        .long MULTIBOOT_HEADER_MAGIC
-        .long MULTIBOOT_HEADER_FLAGS
-        .long -(MULTIBOOT_HEADER_MAGIC+MULTIBOOT_HEADER_FLAGS)*/
-
-/** Global Descriptor Table (GDT) during boot.
- * see 3.4.5.1 Code- and Data-Segment Descriptor Types in Intel 253668-048US.
- * granularity 0xa0 = 10100000b => limit granularity 4kb, operand size unset, 64bit mode
- * access 0x9b = 10011011b => present, ring0, code/data, Execute/Read accessed
- *  0011 read/write accessed
- *  1001 execute only accessed
- *  1011 execute/read accessed
- *  access 0xfb = 11111011 => present, ring3, code/data, Execute/Read accessed
- *  limit can be 0 because it is not used in 64bit mode
- */
-.align  8
-.global _boot_gdt_start
-_boot_gdt_start:
-        .quad   0x0000000000000000      // null descriptor
-        .quad   0x0000000000000000      // 0x08 unused
-        .quad   0x00a09b000000ffff      // 0x10 kernel code
-        .quad   0x00a093000000ffff      // 0x18 kernel data
-_boot_gdt_end:
-        .word   0                       // padding to align ...
-_boot_gdt:
-        .word   _boot_gdt_end - _boot_gdt_start - 1     // limit: length of the GDT
-        .quad   _boot_gdt_start                 // base
-
-/*.align 8
-.global _mboot_table
-_mboot_table:   .quad   0
-.global _mboot_magic
-_mboot_magic:   .quad   0*/
-
-/* just for testing */
-//.global _host_info_ptr
-//_host_info_ptr:   .quad   0
-
-/* start code for the bootstrap processor BSP, i.e. the first core */
-/*.code32
-.align  8
-.global _start_bsp
-.type _start_bsp, @function
-_start_bsp:
-        // eax and ebx contains the multiboot magic and table pointer,
-        // lets store this for later.
-        mov %eax, _mboot_magic
-        mov %ebx, _mboot_table
-
-        // activate the initial page table
-        mov     $(EFER_MSR), %ecx       // select the EFER MSR
-        rdmsr                           // read EFER
-        and     $(EFER_MASK), %eax
-        or      $(EFER_ENABLE), %eax
-        wrmsr                           // write EFER
-        mov     %cr4, %edx
-        and     $(CR4_MASK), %edx
-        or      $(CR4_ENABLE), %edx
-        mov     %edx, %cr4
-        mov     $(BOOT_PML4-VIRT_ADDR), %edx // pointer to the Page Directory
-        mov     %edx, %cr3
-        mov     %cr0, %edx
-        and     $(CR0_MASK), %edx
-        or      $(CR0_ENABLE), %edx
-        mov     %edx, %cr0  // switch to protected mode, with paging enabled and write protect
-
-        // load our own segment descriptor table
-        lgdt    _boot_gdt
-        ljmp    $0x10, $_start_bsp64    // switch CS to 64bit mode
-*/
-.code64
-.align 8
-.global _start_bsp64_pregdt
-.type _start_bsp64_pregdt, @function
-_start_bsp64_pregdt:
-        mov $(BOOT_STACK+BOOT_STACK_SIZE), %rsp    // set up boot kernel stack
-        // load our own segment descriptor table, see above in this file
-        // the segments 0x10 and 0x18 match the final GDT of the kernel
-        lgdt    _boot_gdt
-        // switch code segment to 0x10 instead of leftovers from the loader
-        // create a stack frame like from a far call and return
-        push    $0x10 // KERNEL_CS
-        push    $_start_bsp64
-        retfq
-
-_start_bsp64:
-        mov     $0x18, %cx      // kernel data selector
-        mov     %cx, %ss
-        mov     %cx, %ds
-        mov     %cx, %es
-        mov     %cx, %fs
-        mov     %cx, %gs
-        cld // for gcc code
-
-        mov     $(EFER_MSR), %ecx       // select the EFER MSR
-        rdmsr                           // read EFER
-        and     $(EFER_MASK), %eax
-        or      $(EFER_ENABLE), %eax
-        wrmsr                           // write EFER
-
-        // go to the stage 3 boot code, and never come back
-        xor %rbp, %rbp
-        pushq   $0 // fake return address as first stack frame
-        jmp entry_bsp
 
 .section .text
 

--- a/kernel/boot/kernel-amd64-knc/boot/boot.ld
+++ b/kernel/boot/kernel-amd64-knc/boot/boot.ld
@@ -49,8 +49,8 @@ SECTIONS
     /* load the boot code at VMA=LMA LOAD_ADDR */
     .init LOAD_ADDR : AT(LOAD_ADDR)
     {
-        KEEP(*(.init))
-    } : init /* put into init segment */
+        KEEP(*(.bootlower))
+    } : bootlower /* put into init segment */
     PROVIDE (LOAD_END = .);
 
     /* the begin of the upper half code and data in physical memory */

--- a/kernel/boot/kernel-amd64-knc/boot/boot.ld
+++ b/kernel/boot/kernel-amd64-knc/boot/boot.ld
@@ -47,10 +47,10 @@ SECTIONS
 {
     /* LOAD_ADDR is begin of the init code and data */
     /* load the boot code at VMA=LMA LOAD_ADDR */
-    .init LOAD_ADDR : AT(LOAD_ADDR)
+    .bootlower LOAD_ADDR : AT(LOAD_ADDR)
     {
         KEEP(*(.bootlower))
-    } : bootlower /* put into init segment */
+    } : init /* put into init segment */
     PROVIDE (LOAD_END = .);
 
     /* the begin of the upper half code and data in physical memory */

--- a/kernel/boot/kernel-amd64-knc/boot/start.S
+++ b/kernel/boot/kernel-amd64-knc/boot/start.S
@@ -31,7 +31,7 @@
 .extern entry_bsp
 .extern entry_ap
 
-.section .init, "awx"  // the following code and data is in the low memory init section
+.section .bootlower, "awx"  // the following code and data is in the low memory init section
 
 // EFER bit 0: SYSCALL instruction enable
 // EFER bit 8: IA-32e mode enable

--- a/kernel/boot/kernel-amd64-pc/boot/boot.ld
+++ b/kernel/boot/kernel-amd64-pc/boot/boot.ld
@@ -45,12 +45,12 @@ PHDRS
 
 SECTIONS
 {
-    /* LOAD_ADDR is begin of the init code and data */
+    /* LOAD_ADDR is begin of the lower half boot code and data */
     /* load the boot code at VMA=LMA LOAD_ADDR */
     .bootlower LOAD_ADDR : AT(LOAD_ADDR)
     {
         KEEP(*(.bootlower))
-    } : bootlower /* put into init segment */
+    } : bootlower /* put into boot segment */
     PROVIDE (LOAD_END = .);
 
     /* the begin of the upper half code and data in physical memory */

--- a/kernel/boot/kernel-amd64-pc/boot/boot.ld
+++ b/kernel/boot/kernel-amd64-pc/boot/boot.ld
@@ -38,7 +38,7 @@ ENTRY(_start_bsp)
  */
 PHDRS
 {
-    init PT_LOAD;
+    bootlower PT_LOAD;
     kern PT_LOAD;
     data PT_LOAD;
 }
@@ -47,10 +47,10 @@ SECTIONS
 {
     /* LOAD_ADDR is begin of the init code and data */
     /* load the boot code at VMA=LMA LOAD_ADDR */
-    .init LOAD_ADDR : AT(LOAD_ADDR)
+    .bootlower LOAD_ADDR : AT(LOAD_ADDR)
     {
-        KEEP(*(.init))
-    } : init /* put into init segment */
+        KEEP(*(.bootlower))
+    } : bootlower /* put into init segment */
     PROVIDE (LOAD_END = .);
 
     /* the begin of the upper half code and data in physical memory */

--- a/kernel/boot/kernel-amd64-pc/boot/boot.ld
+++ b/kernel/boot/kernel-amd64-pc/boot/boot.ld
@@ -38,7 +38,7 @@ ENTRY(_start_bsp)
  */
 PHDRS
 {
-    bootlower PT_LOAD;
+    init PT_LOAD;
     kern PT_LOAD;
     data PT_LOAD;
 }
@@ -50,7 +50,7 @@ SECTIONS
     .bootlower LOAD_ADDR : AT(LOAD_ADDR)
     {
         KEEP(*(.bootlower))
-    } : bootlower /* put into boot segment */
+    } : init /* put into init segment */
     PROVIDE (LOAD_END = .);
 
     /* the begin of the upper half code and data in physical memory */

--- a/kernel/boot/kernel-amd64-pc/boot/start.S
+++ b/kernel/boot/kernel-amd64-pc/boot/start.S
@@ -31,7 +31,7 @@
 .extern entry_bsp
 .extern entry_ap
 
-.section .init, "awx"  // the following code and data is in the low memory init section
+.section .bootlower, "awx"  // the following code and data is in the low memory init section
 
 // EFER bit 0: SYSCALL instruction enable
 // EFER bit 8: IA-32e mode enable

--- a/kernel/build/gcc-host-pc/util/compiler.hh
+++ b/kernel/build/gcc-host-pc/util/compiler.hh
@@ -30,8 +30,6 @@
 #define ALIGNED(X)          alignas(X)
 #define ALIGN_4K            alignas(4096)
 #define ALWAYS_INLINE       __attribute__((always_inline))
-#define INIT                __attribute__((section (".bootlower")))
-#define INITDATA            __attribute__((section (".initdata")))
 #define NORETURN            [[noreturn]]
 //__attribute__((noreturn))
 #define NOINLINE            __attribute__((noinline))

--- a/kernel/build/gcc-host-pc/util/compiler.hh
+++ b/kernel/build/gcc-host-pc/util/compiler.hh
@@ -30,7 +30,7 @@
 #define ALIGNED(X)          alignas(X)
 #define ALIGN_4K            alignas(4096)
 #define ALWAYS_INLINE       __attribute__((always_inline))
-#define INIT                __attribute__((section (".init")))
+#define INIT                __attribute__((section (".bootlower")))
 #define INITDATA            __attribute__((section (".initdata")))
 #define NORETURN            [[noreturn]]
 //__attribute__((noreturn))

--- a/kernel/build/gcc-kernel-knc/util/compiler.hh
+++ b/kernel/build/gcc-kernel-knc/util/compiler.hh
@@ -30,8 +30,6 @@
 #define ALIGNED(X)          alignas(X)
 #define ALIGN_4K            alignas(4096)
 #define ALWAYS_INLINE       __attribute__((always_inline))
-// #define INIT                __attribute__((section (".init")))
-// #define INITDATA            __attribute__((section (".initdata")))
 #define NORETURN            [[noreturn]]
 //__attribute__((noreturn))
 #define NOINLINE            __attribute__((noinline))

--- a/kernel/build/gcc-kernel-pc/util/compiler.hh
+++ b/kernel/build/gcc-kernel-pc/util/compiler.hh
@@ -30,8 +30,6 @@
 #define ALIGNED(X)          alignas(X)
 #define ALIGN_4K            alignas(4096)
 #define ALWAYS_INLINE       __attribute__((always_inline))
-// #define INIT                __attribute__((section (".init")))
-// #define INITDATA            __attribute__((section (".initdata")))
 #define NORETURN            [[noreturn]]
 //__attribute__((noreturn))
 #define NOINLINE            __attribute__((noinline))

--- a/kernel/runtime/crt-init/runtime/crtend.S
+++ b/kernel/runtime/crt-init/runtime/crtend.S
@@ -24,7 +24,7 @@
  * Copyright 2016 Randolf Rotta, Robert Kuban, and contributors, BTU Cottbus-Senftenberg
  */
 
-.section .bootlower
+.section .init
 	pop %rbp
 	ret
 

--- a/kernel/runtime/crt-init/runtime/crtend.S
+++ b/kernel/runtime/crt-init/runtime/crtend.S
@@ -24,7 +24,7 @@
  * Copyright 2016 Randolf Rotta, Robert Kuban, and contributors, BTU Cottbus-Senftenberg
  */
 
-.section .init
+.section .bootlower
 	pop %rbp
 	ret
 

--- a/kernel/runtime/crt-init/runtime/start.S
+++ b/kernel/runtime/crt-init/runtime/start.S
@@ -53,10 +53,10 @@ __dso_handle:
 .skip  8
 .hidden __dso_handle
 
-.section .init
-.global _init
-.type _init,@function
-_init:
+.section .bootlower
+.global _bootlower
+.type _bootlower,@function
+_bootlower:
         push %rbp
         mov %rsp, %rbp
 

--- a/kernel/runtime/crt-init/runtime/start.S
+++ b/kernel/runtime/crt-init/runtime/start.S
@@ -35,13 +35,9 @@
 _start:
         mov initstack_top, %rsp
         xor %rbp, %rbp
-        mov %rdi, msg_ptr       // store first argument to global variable
-/*        fninit                  // initialize the FPU
-        call __libc_init_array*/
+        mov %rdi, msg_ptr       /* store first argument to global variable */
         call start_c
-/*        mov $0, %rdi
-        call exit
-1:      jmp 1b*/
+1:      jmp 1b                  /* should never return from start_c anyway */
 
 /* A handle for __cxa_finalize to manage c++ local destructors.  */
 .global __dso_handle


### PR DESCRIPTION
Cleaning up the mixed up segments versus sections in the change from .init to .bootlower.
Cleaning the start assembler in the IHK part.