### PR TITLE
Use kernel offset instead off physical address when setting CapRef data.

### DIFF
--- a/kernel/app/init-example/app/init.cc
+++ b/kernel/app/init-example/app/init.cc
@@ -483,7 +483,7 @@ int main()
 
   test_float();
   test_Example();
-  //test_Portal();
+  test_Portal();
   test_heap(); // heap must be initialized for tls test
   test_tls();
   test_exceptions();

--- a/kernel/app/init-example/app/init.cc
+++ b/kernel/app/init-example/app/init.cc
@@ -492,7 +492,7 @@ int main()
   test_ExecutionContext();
   //test_pthreads();
   test_Rapl();
-  test_CgaScreen();
+  //test_CgaScreen();
 
   char const end[] = "bye, cruel world!";
   mythos::syscall_debug(end, sizeof(end)-1);

--- a/kernel/objects/capability-utils/objects/CapRef.cc
+++ b/kernel/objects/capability-utils/objects/CapRef.cc
@@ -39,7 +39,7 @@ namespace mythos {
     this->reset();
     RETURN(cap::setReference(
         this->entry,
-        srcCap.asReference(this, kernel2phys(subject)),
+        srcCap.asReference(this, kernel2offset(subject)),
         src, srcCap,
         [=](){
           this->orig.store(srcCap.asReference().value());

--- a/kernel/objects/capability-utils/objects/CapRef.hh
+++ b/kernel/objects/capability-utils/objects/CapRef.hh
@@ -122,9 +122,7 @@ namespace mythos {
 
     void unbinding(void* subject, Cap orig) override {
       ASSERT(orig.isUsable());
-      auto obj = orig.getPtr()->cast<Object>();
-      Revoker::unbinding(static_cast<Subject*>(subject), obj);
-      MLOG_INFO(mlog::cap,"before return");
+      Revoker::unbinding(static_cast<Subject*>(subject), orig.getPtr()->cast<Object>());
     }
   };
 

--- a/kernel/objects/capability-utils/objects/CapRef.hh
+++ b/kernel/objects/capability-utils/objects/CapRef.hh
@@ -122,7 +122,9 @@ namespace mythos {
 
     void unbinding(void* subject, Cap orig) override {
       ASSERT(orig.isUsable());
-      Revoker::unbinding(static_cast<Subject*>(subject), orig.getPtr()->cast<Object>());
+      auto obj = orig.getPtr()->cast<Object>();
+      Revoker::unbinding(static_cast<Subject*>(subject), obj);
+      MLOG_INFO(mlog::cap,"before return");
     }
   };
 


### PR DESCRIPTION
Closes #157. Interesting that this surfaced just now.