### PR TITLE
search a free address for the first ipc buffer

### DIFF
--- a/kernel/app/init-example/app/init.cc
+++ b/kernel/app/init-example/app/init.cc
@@ -100,7 +100,7 @@ void test_Portal()
   MLOG_ERROR(mlog::app, "test_Portal begin");
   mythos::PortalLock pl(portal); // future access will fail if the portal is in use already
   MLOG_INFO(mlog::app, "test_Portal: allocate portal");
-  uintptr_t vaddr = 22*1024*1024; // choose address different from invokation buffer
+  uintptr_t vaddr = mythos::round_up(uintptr_t(msg_ptr) + 1,  mythos::align2M);
   // allocate a portal
   mythos::Portal p2(capAlloc(), (void*)vaddr);
   auto res1 = p2.create(pl, kmem).wait();
@@ -196,9 +196,9 @@ void test_tls()
 void test_heap() {
   MLOG_INFO(mlog::app, "Test heap");
   mythos::PortalLock pl(portal);
-  uintptr_t vaddr = 24*1024*1024; // choose address different from invokation buffer
   auto size = 4*1024*1024; // 2 MB
   auto align = 2*1024*1024; // 2 MB
+  uintptr_t vaddr = mythos::round_up(uintptr_t(msg_ptr) + 1,  align);
   // allocate a 2MiB frame
   mythos::Frame f(capAlloc());
   auto res2 = f.create(pl, kmem, size, align).wait();

--- a/kernel/boot/init-loader-amd64/boot/load_init.cc
+++ b/kernel/boot/init-loader-amd64/boot/load_init.cc
@@ -69,14 +69,14 @@ optional<void> InitLoader::load()
 {
   if (!_img.isValid()) RETURN(Error::GENERIC_ERROR);
 
-  uintptr_t ipc_vaddr = 10ull << 21;
-
   // order matters here
   optional<void> res(Error::SUCCESS);
   if (res) res = initCSpace();
-  if (res) res = createPortal(ipc_vaddr, init::PORTAL);
-  if (res) res = loadImage();
-  if (res) res = createEC(ipc_vaddr);
+  auto ipc_vaddr = loadImage();
+  res = ipc_vaddr;
+  if (res) MLOG_INFO(mlog::boot, "init invokation buffer", DVARhex(*ipc_vaddr));
+  if (res) res = createPortal(*ipc_vaddr, init::PORTAL);
+  if (res) res = createEC(*ipc_vaddr);
   RETURN(res);
 }
 
@@ -198,8 +198,9 @@ optional<void> InitLoader::createPortal(uintptr_t ipc_vaddr, CapPtr dstPortal)
     RETURN(Error::SUCCESS);
 }
 
-optional<void> InitLoader::loadImage()
+optional<uintptr_t> InitLoader::loadImage()
 {
+    uintptr_t ipc_addr = round_up(1u, align2M);
     // 1) figure out how much bytes we need
     size_t size = 0;
     for (size_t i=0; i <_img.phnum(); ++i) {
@@ -208,6 +209,9 @@ optional<void> InitLoader::loadImage()
             auto begin = round_down(ph->vaddr, align2M);
             auto end = round_up(ph->vaddr + ph->memsize, align2M);
             size += end-begin;
+            if (end >= ipc_addr) {
+              ipc_addr = round_up(end + 1u, align2M);
+            }
         }
     }
 
@@ -229,7 +233,7 @@ optional<void> InitLoader::loadImage()
             offset += end-begin;
         }
     }
-    RETURN(Error::SUCCESS);
+    return ipc_addr;
 }
 
 optional<void> InitLoader::loadProgramHeader(

--- a/kernel/boot/init-loader-amd64/boot/load_init.hh
+++ b/kernel/boot/init-loader-amd64/boot/load_init.hh
@@ -56,7 +56,7 @@ namespace mythos {
 
       optional<void> initCSpace();
       optional<void> createPortal(uintptr_t ipc_vaddr, CapPtr dstPortal);
-      optional<void> loadImage();
+      optional<uintptr_t> loadImage();
       optional<void> createEC(uintptr_t ipc_vaddr);
 
       optional<void> loadProgramHeader(


### PR DESCRIPTION
This solves an issue when using different-sized init applications. It's also a step towards less hard-coded values in the runtime.
Alternatively, we could consider passing a (low, high) address tuple of reserved virtual addresses to the application.

P.S.: I was surprised how painless this was to implement 👍 