### PR TITLE
I170 port fixes from feature branches

### DIFF
--- a/kernel/boot/kernel-amd64-ihk/util/PhysPtr.hh
+++ b/kernel/boot/kernel-amd64-ihk/util/PhysPtr.hh
@@ -57,6 +57,8 @@ namespace mythos {
   public:
     PhysPtr() : ptr(0) {}
 
+    PhysPtr(const PhysPtr<T>&) = default;
+
     explicit PhysPtr(uint64_t ptr) : ptr(ptr) {}
 
     static PhysPtr fromImage(T* vp) {
@@ -134,6 +136,9 @@ namespace mythos {
   {
   public:
     PhysPtr32() : ptr(0) {}
+
+    PhysPtr32(const PhysPtr32<T>&) = default;
+    
     explicit PhysPtr32(uint32_t ptr) : ptr(ptr) {}
     explicit PhysPtr32(uint64_t ptr) : ptr(uint32_t(ptr)) {
       ASSERT(ptr <= 0xFFFFFFFF);

--- a/kernel/cpu/ctrlregs-amd64/cpu/ctrlregs.hh
+++ b/kernel/cpu/ctrlregs-amd64/cpu/ctrlregs.hh
@@ -324,7 +324,7 @@ namespace mythos {
 
   class IOPort8 {
     public:
-      IOPort8 (unsigned port)
+      IOPort8 (uint16_t port)
       : port(port)
       {}
 
@@ -344,7 +344,7 @@ namespace mythos {
 
   class IOPort16 {
     public:
-      IOPort16 (unsigned port)
+      IOPort16 (uint16_t port)
       : port(port)
       {}
 

--- a/kernel/util/address/util/PhysPtr.hh
+++ b/kernel/util/address/util/PhysPtr.hh
@@ -54,6 +54,8 @@ namespace mythos {
   public:
     PhysPtr() : ptr(0) {}
 
+    PhysPtr(const PhysPtr<T>&) = default;
+    
     explicit PhysPtr(uint64_t ptr) : ptr(ptr) {}
 
     static PhysPtr fromImage(T* vp) {
@@ -144,6 +146,9 @@ namespace mythos {
   {
   public:
     PhysPtr32() : ptr(0) {}
+    
+    PhysPtr32(const PhysPtr32<T>&) = default;
+
     explicit PhysPtr32(uint32_t ptr) : ptr(ptr) {}
     explicit PhysPtr32(uint64_t ptr) : ptr(uint32_t(ptr)) {
       ASSERT(ptr <= 0xFFFFFFFF);


### PR DESCRIPTION
fixed warning in PhysPtr and IOPort as mentioned in #170.
MMAP in cxx-support was already aligned.

Compiles and runs without warning/error for platform IHK/QEMU.
Kernel-KNC: compilation fails with: 
```
./runtime/brk.hh:28:10: fatal error: cstdint: No such file or directory
   28 | #include <cstdint>
      |          ^~~~~~~~~
compilation terminated.
```