### PR TITLE
I184 futex requeue

### DIFF
--- a/kernel/runtime/cxx/runtime/cxxsupport.cc
+++ b/kernel/runtime/cxx/runtime/cxxsupport.cc
@@ -188,7 +188,7 @@ extern "C" long mythos_musl_syscall(
             uint32_t val2 = 0;
             return do_futex(reinterpret_cast<uint32_t*>(a1) /*uaddr*/, 
                             a2 /*op*/, a3 /*val*/, reinterpret_cast<uint32_t*>(a4)/* timeout*/, 
-                            nullptr /*uaddr2*/, val2/*val2*/, a6/*val3*/);
+                            reinterpret_cast<uint32_t*>(a5) /*uaddr2*/, a4/*val2*/, a6/*val3*/);
         }
     case 203: // sched_setaffinity
         return sched_setaffinity(a1, a2, reinterpret_cast<cpu_set_t*>(a3));

--- a/kernel/runtime/cxx/runtime/futex.cc
+++ b/kernel/runtime/cxx/runtime/futex.cc
@@ -211,7 +211,10 @@ static int futex_requeue(uint32_t *uaddr /*&barrier*/, unsigned int flags, uint3
     // that are requeued to the futex at uaddr2.
     {
       uint32_t hashTo = hash_futex(uaddr2);
-      mythos::Mutex::Lock guard2(queue[hashTo].readLock);
+      // if the hashes of the source queue equal the destination queue, use dummy mutux because the tidex mutex 
+      // cannot be locked twice by the same thread
+      mythos::Mutex dummy; 
+      mythos::Mutex::Lock guard2( hashTo != hashFrom? queue[hashTo].readLock : dummy);
       MLOG_DETAIL(mlog::app, "requeue waiters", DVAR(hashTo) );
       for (int i = 0; i < val2; i++) {
           while (curr->load(std::memory_order_relaxed) && curr->load(std::memory_order_relaxed)->uaddr != uaddr) {


### PR DESCRIPTION
Implemented futex requeue as mentioned in #184.
Tested with external barnes hut application using qemu.
This test does not use the wake-up part of requeue function (but this part is copied from futex_wake).
No warnings.