### PR TITLE
disables MSR read for unknown CPUs in RAPL driver.

### DIFF
--- a/kernel/app/init-example/app/init.cc
+++ b/kernel/app/init-example/app/init.cc
@@ -492,7 +492,7 @@ int main()
   //test_HostChannel(portal, 24*1024*1024, 2*1024*1024);
   test_ExecutionContext();
   test_pthreads();
-  //test_Rapl();
+  test_Rapl();
   //test_CgaScreen();
 
   char const end[] = "bye, cruel world!";

--- a/kernel/objects/rapl-driver-intel/objects/RaplDriverIntel.hh
+++ b/kernel/objects/rapl-driver-intel/objects/RaplDriverIntel.hh
@@ -48,10 +48,13 @@ private:
   bool isIntel;
   uint32_t cpu_fam;
   uint32_t cpu_model;
+
 	uint32_t dram_avail;
 	bool pp0_avail;
 	bool pp1_avail;
 	bool psys_avail;
+	bool pkg_avail;
+
 	bool different_units;
   uint32_t power_units;
   uint32_t time_units;


### PR DESCRIPTION
This avoids reading the MSR in case of an unknown/unsupported CPU, which would lead to crashes otherwise. I'm not sure if this covers all the cases were MSRs in this driver can't be read on all/most machines. Especially the package power is measured without checking a feature flag.