### PR TITLE
reading error code and CR2

### DIFF
--- a/kernel/mythos/invocation/mythos/protocol/ExecutionContext.hh
+++ b/kernel/mythos/invocation/mythos/protocol/ExecutionContext.hh
@@ -80,6 +80,9 @@ namespace mythos {
         uint64_t rbp = 0;
         uint64_t fs_base = 0;
         uint64_t gs_base = 0;
+        uint64_t irq = 0; // read-only
+        uint64_t error = 0; // read-only
+        uint64_t cr2 = 0; // read-only
       };
 
       // has WriteRegisters message as result

--- a/kernel/objects/execution-context/objects/ExecutionContext.cc
+++ b/kernel/objects/execution-context/objects/ExecutionContext.cc
@@ -237,6 +237,9 @@ namespace mythos {
         respData->regs.rbp = threadState.rbp;
         respData->regs.fs_base = threadState.fs_base;
         respData->regs.gs_base = threadState.gs_base;
+        respData->regs.irq = threadState.irq;
+        respData->regs.error = threadState.error;
+        respData->regs.cr2 = threadState.cr2;
         clearFlagsResume(REGISTER_ACCESS);
         msg->replyResponse(Error::SUCCESS);
         msg = nullptr;


### PR DESCRIPTION
extended the ExecutionContext invocation to read the error code and CR2 register as well.